### PR TITLE
fix: resolve SVG fill conflicts in path elements and arrow markers

### DIFF
--- a/docs/assets/images/diagrams/chapter01/04_repository_concept.svg
+++ b/docs/assets/images/diagrams/chapter01/04_repository_concept.svg
@@ -17,7 +17,7 @@
     
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="3" 
             markerWidth="6" markerHeight="6" orient="auto">
-      <path d="M0,0 L0,6 L9,3 z" class="primary" fill="none"/>
+      <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
     </marker>
   </defs>
   
@@ -145,11 +145,11 @@
     <!-- 同期の矢印 -->
     <g class="sync-arrows">
       <!-- Push -->
-      <path d="M 300 420 Q 350 400 500 420" fill="none" class="primary-stroke" marker-end="url(#arrow)"/>
+      <path d="M 300 420 Q 350 400 500 420" fill="none" stroke="#2563eb" stroke-width="2" marker-end="url(#arrow)"/>
       <text x="400" y="410" text-anchor="middle" class="text text-sm primary">Push</text>
       
       <!-- Pull -->
-      <path d="M 500 460 Q 450 480 300 460" fill="none" class="success" stroke-width="2" marker-end="url(#arrow)"/>
+      <path d="M 500 460 Q 450 480 300 460" fill="none" stroke="#10b981" stroke-width="2" marker-end="url(#arrow)"/>
       <text x="400" y="490" text-anchor="middle" class="text text-sm success">Pull</text>
     </g>
   </g>

--- a/docs/assets/images/diagrams/chapter01/05_collaboration_flow.svg
+++ b/docs/assets/images/diagrams/chapter01/05_collaboration_flow.svg
@@ -17,7 +17,7 @@
     
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="3" 
             markerWidth="6" markerHeight="6" orient="auto">
-      <path d="M0,0 L0,6 L9,3 z" class="primary" fill="none"/>
+      <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
     </marker>
   </defs>
   
@@ -152,7 +152,7 @@
     <line x1="600" y1="480" x2="640" y2="480" class="primary-stroke" marker-end="url(#arrow)"/>
     
     <!-- フィードバックループ -->
-    <path d="M 460 460 Q 400 420 350 440" fill="none" class="warning" stroke-width="1" stroke-dasharray="5,5" marker-end="url(#arrow)"/>
+    <path d="M 460 460 Q 400 420 350 440" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,5" marker-end="url(#arrow)"/>
     <text x="400" y="430" text-anchor="middle" class="text text-sm warning">修正要求</text>
   </g>
   

--- a/docs/assets/images/diagrams/chapter01/08_development_workflow_overview.svg
+++ b/docs/assets/images/diagrams/chapter01/08_development_workflow_overview.svg
@@ -17,7 +17,7 @@
     
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="3" 
             markerWidth="6" markerHeight="6" orient="auto">
-      <path d="M0,0 L0,6 L9,3 z" class="primary" fill="none"/>
+      <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
     </marker>
   </defs>
   
@@ -182,7 +182,7 @@
       <line x1="615" y1="300" x2="665" y2="300" class="primary-stroke" marker-end="url(#arrow)"/>
       
       <!-- フィードバックループ -->
-      <path d="M 600 285 Q 400 250 280 285" fill="none" class="warning" stroke-width="1" stroke-dasharray="5,5" marker-end="url(#arrow)"/>
+      <path d="M 600 285 Q 400 250 280 285" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,5" marker-end="url(#arrow)"/>
       <text x="440" y="265" text-anchor="middle" class="text text-sm warning">修正フィードバック</text>
       
       <!-- 繰り返し作業 -->

--- a/docs/assets/images/diagrams/chapter04/01_git_basic_operations.svg
+++ b/docs/assets/images/diagrams/chapter04/01_git_basic_operations.svg
@@ -17,7 +17,7 @@
     
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="3" 
             markerWidth="6" markerHeight="6" orient="auto">
-      <path d="M0,0 L0,6 L9,3 z" class="primary" fill="none"/>
+      <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
     </marker>
     
     <marker id="arrow-success" viewBox="0 0 10 10" refX="9" refY="3" 
@@ -65,33 +65,33 @@
   
   <!-- Clone操作 -->
   <g class="clone-operations">
-    <path d="M 360 160 Q 260 220 200 280" fill="none" class="neutral" stroke-width="3" marker-end="url(#arrow)"/>
+    <path d="M 360 160 Q 260 220 200 280" fill="none" stroke="#64748b" stroke-width="3" marker-end="url(#arrow)"/>
     <text x="280" y="200" text-anchor="middle" class="text text-sm" style="font-weight: 600;">git clone</text>
     <text x="280" y="215" text-anchor="middle" class="text text-sm">初回複製</text>
     
-    <path d="M 440 160 Q 540 220 600 280" fill="none" class="neutral" stroke-width="3" marker-end="url(#arrow)"/>
+    <path d="M 440 160 Q 540 220 600 280" fill="none" stroke="#64748b" stroke-width="3" marker-end="url(#arrow)"/>
     <text x="520" y="200" text-anchor="middle" class="text text-sm" style="font-weight: 600;">git clone</text>
     <text x="520" y="215" text-anchor="middle" class="text text-sm">初回複製</text>
   </g>
   
   <!-- Push操作 -->
   <g class="push-operations">
-    <path d="M 200 280 Q 260 220 360 160" fill="none" class="success" stroke-width="2" marker-end="url(#arrow-success)"/>
+    <path d="M 200 280 Q 260 220 360 160" fill="none" stroke="#10b981" stroke-width="2" marker-end="url(#arrow-success)"/>
     <text x="280" y="240" text-anchor="middle" class="text text-sm success" style="font-weight: 600;">git push</text>
     <text x="280" y="255" text-anchor="middle" class="text text-sm success">変更をアップロード</text>
     
-    <path d="M 600 280 Q 540 220 440 160" fill="none" class="success" stroke-width="2" marker-end="url(#arrow-success)"/>
+    <path d="M 600 280 Q 540 220 440 160" fill="none" stroke="#10b981" stroke-width="2" marker-end="url(#arrow-success)"/>
     <text x="520" y="240" text-anchor="middle" class="text text-sm success" style="font-weight: 600;">git push</text>
     <text x="520" y="255" text-anchor="middle" class="text text-sm success">変更をアップロード</text>
   </g>
   
   <!-- Pull操作 -->
   <g class="pull-operations">
-    <path d="M 380 160 Q 320 220 240 280" fill="none" class="warning" stroke-width="2" marker-end="url(#arrow-warning)"/>
+    <path d="M 380 160 Q 320 220 240 280" fill="none" stroke="#f59e0b" stroke-width="2" marker-end="url(#arrow-warning)"/>
     <text x="310" y="235" text-anchor="middle" class="text text-sm warning" style="font-weight: 600;">git pull</text>
     <text x="310" y="250" text-anchor="middle" class="text text-sm warning">変更をダウンロード</text>
     
-    <path d="M 420 160 Q 480 220 560 280" fill="none" class="warning" stroke-width="2" marker-end="url(#arrow-warning)"/>
+    <path d="M 420 160 Q 480 220 560 280" fill="none" stroke="#f59e0b" stroke-width="2" marker-end="url(#arrow-warning)"/>
     <text x="490" y="235" text-anchor="middle" class="text text-sm warning" style="font-weight: 600;">git pull</text>
     <text x="490" y="250" text-anchor="middle" class="text text-sm warning">変更をダウンロード</text>
   </g>

--- a/docs/assets/images/diagrams/chapter04/05_branch_file_operations.svg
+++ b/docs/assets/images/diagrams/chapter04/05_branch_file_operations.svg
@@ -17,7 +17,7 @@
     
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="3" 
             markerWidth="6" markerHeight="6" orient="auto">
-      <path d="M0,0 L0,6 L9,3 z" class="primary" fill="none"/>
+      <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
     </marker>
   </defs>
   
@@ -52,7 +52,7 @@
     <!-- feature/loginブランチ -->
     <g class="feature-branch">
       <path d="M 250 100 Q 270 130 290 160 L 480 160 Q 500 130 520 100" 
-            fill="none" class="primary" stroke-width="3"/>
+            fill="none" stroke="#2563eb" stroke-width="3"/>
       <text x="80" y="165" text-anchor="end" class="text text-sm primary" style="font-weight: 600;">feature/login</text>
       
       <!-- featureのコミット -->
@@ -69,7 +69,7 @@
     <!-- hotfix/bugfixブランチ -->
     <g class="hotfix-branch">
       <path d="M 400 100 Q 420 70 440 40 L 540 40 Q 560 70 580 100" 
-            fill="none" class="error" stroke-width="3"/>
+            fill="none" stroke="#ef4444" stroke-width="3"/>
       <text x="80" y="45" text-anchor="end" class="text text-sm error" style="font-weight: 600;">hotfix/bugfix</text>
       
       <!-- hotfixのコミット -->

--- a/docs/assets/images/diagrams/chapter04/06_merge_concept.svg
+++ b/docs/assets/images/diagrams/chapter04/06_merge_concept.svg
@@ -17,7 +17,7 @@
     
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="3" 
             markerWidth="6" markerHeight="6" orient="auto">
-      <path d="M0,0 L0,6 L9,3 z" class="primary" fill="none"/>
+      <path d="M0,0 L0,6 L9,3 z" fill="#2563eb"/>
     </marker>
   </defs>
   
@@ -43,7 +43,7 @@
     
     <!-- featureブランチ -->
     <path d="M 120 120 Q 140 140 160 160 L 240 160" 
-          fill="none" class="primary" stroke-width="3"/>
+          fill="none" stroke="#2563eb" stroke-width="3"/>
     <text x="30" y="165" text-anchor="end" class="text text-sm primary" style="font-weight: 600;">feature</text>
     
     <circle cx="180" cy="160" r="5" class="primary"/>
@@ -72,7 +72,7 @@
     
     <!-- マージされたfeatureブランチ -->
     <path d="M 520 120 Q 540 140 560 160 L 620 160" 
-          fill="none" class="primary" stroke-width="3"/>
+          fill="none" stroke="#2563eb" stroke-width="3"/>
     
     <circle cx="580" cy="160" r="5" class="primary"/>
     <circle cx="620" cy="160" r="5" class="primary"/>
@@ -122,12 +122,12 @@
       <!-- Before -->
       <text x="310" y="305" class="text text-sm" style="font-weight: 600;">マージ前:</text>
       <line x1="310" y1="315" x2="360" y2="315" class="success" stroke-width="2"/>
-      <path d="M 340 315 L 370 325 L 420 325" fill="none" class="primary" stroke-width="2"/>
+      <path d="M 340 315 L 370 325 L 420 325" fill="none" stroke="#2563eb" stroke-width="2"/>
       
       <!-- After -->
       <text x="310" y="345" class="text text-sm" style="font-weight: 600;">マージ後:</text>
       <line x1="310" y1="355" x2="450" y2="355" class="success" stroke-width="2"/>
-      <path d="M 340 355 L 370 365 L 420 365 L 450 355" fill="none" class="primary" stroke-width="2"/>
+      <path d="M 340 355 L 370 365 L 420 365 L 450 355" fill="none" stroke="#2563eb" stroke-width="2"/>
       
       <text x="400" y="375" text-anchor="middle" class="text text-sm">マージコミット作成</text>
     </g>
@@ -140,7 +140,7 @@
       <!-- Before -->
       <text x="530" y="305" class="text text-sm" style="font-weight: 600;">マージ前:</text>
       <line x1="530" y1="315" x2="580" y2="315" class="success" stroke-width="2"/>
-      <path d="M 560 315 L 590 325 L 640 325" fill="none" class="primary" stroke-width="2"/>
+      <path d="M 560 315 L 590 325 L 640 325" fill="none" stroke="#2563eb" stroke-width="2"/>
       <circle cx="610" cy="325" r="2" class="primary"/>
       <circle cx="625" cy="325" r="2" class="primary"/>
       


### PR DESCRIPTION
## Summary
This PR fixes SVG fill conflicts identified in Issue #11 where path elements had conflicting fill attributes, causing rendering issues with curves and arrows.

### Problem
- Path elements had both CSS classes that defined fill colors AND `fill="none"` attributes
- Arrow markers had conflicting `class="primary" fill="none"` attributes
- This caused inconsistent rendering and unwanted fill effects on paths that should only have strokes

### Technical Fix
- Replaced CSS class-based fill definitions with direct `stroke` color attributes
- Fixed arrow markers to use direct `fill` attributes instead of conflicting class/fill combinations
- Ensured all curved paths (`Q` quadratic curves) and line paths properly use stroke instead of fill

### Fixed Files
- ✅ **chapter01/04_repository_concept.svg**: Fixed curved Push/Pull arrow paths and marker
- ✅ **chapter01/05_collaboration_flow.svg**: Fixed feedback loop path and marker
- ✅ **chapter01/08_development_workflow_overview.svg**: Fixed workflow arrow path and marker  
- ✅ **chapter04/01_git_basic_operations.svg**: Fixed multiple operation flow paths and marker
- ✅ **chapter04/05_branch_file_operations.svg**: Fixed branch flow paths and marker
- ✅ **chapter04/06_merge_concept.svg**: Fixed merge flow paths and marker

### Test Plan
- [x] All modified SVG files render correctly without unwanted fill effects
- [x] Curved paths display as stroke-only lines as intended
- [x] Arrow markers display with proper fill colors
- [x] No visual regressions in diagram appearance

## Related Issues
Addresses fill issues mentioned in Issue #11

🤖 Generated with [Claude Code](https://claude.ai/code)