### PR TITLE
fix: resolve sidebar stuck visible with proper transform control

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -173,7 +173,7 @@ a:hover {
     font-weight: 600;
 }
 
-/* Sidebar */
+/* Sidebar - Desktop default, mobile overridden by mobile-responsive.css */
 .book-sidebar {
     position: fixed;
     top: var(--header-height);
@@ -184,7 +184,7 @@ a:hover {
     border-right: 1px solid var(--border-color);
     overflow-y: auto;
     z-index: 900;
-    transform: translateX(0);
+    /* Remove fixed transform to allow mobile-responsive.css control */
     transition: transform 0.3s ease;
 }
 

--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -15,7 +15,7 @@
    ============================================ */
 
 @media (min-width: 768px) {
-  /* Reset sidebar to normal desktop behavior */
+  /* Force sidebar to normal desktop behavior - override all mobile styles */
   .book-sidebar {
     position: fixed !important;
     transform: translateX(0) !important;
@@ -24,6 +24,7 @@
     box-shadow: none !important;
     opacity: 1 !important;
     pointer-events: auto !important;
+    display: block !important;
   }
   
   /* Hide hamburger menu on desktop */
@@ -34,12 +35,14 @@
   /* Hide overlay on desktop */
   .book-sidebar-overlay {
     display: none !important;
+    visibility: hidden !important;
   }
   
-  /* Reset checkbox effect on desktop */
+  /* Force checkbox effect to have no impact on desktop */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
     background: var(--bg-primary) !important;
+    opacity: 1 !important;
   }
 }
 
@@ -48,21 +51,23 @@
    ============================================ */
 
 @media (max-width: 767px) {
-  /* Mobile sidebar - default hidden state */
+  /* Mobile sidebar - FORCE hidden state by default */
   .book-sidebar {
-    display: block;
-    position: fixed;
-    top: var(--header-height, 60px);
-    left: 0;
-    width: 280px;
-    height: calc(100vh - var(--header-height, 60px));
-    background: transparent;
-    border-right: none;
-    padding: 1rem;
-    overflow-y: auto;
-    z-index: 1000;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease-in-out;
+    display: block !important;
+    position: fixed !important;
+    top: var(--header-height, 60px) !important;
+    left: 0 !important;
+    width: 280px !important;
+    height: calc(100vh - var(--header-height, 60px)) !important;
+    background: transparent !important;
+    border-right: none !important;
+    padding: 1rem !important;
+    overflow-y: auto !important;
+    z-index: 1000 !important;
+    transform: translateX(-100%) !important;
+    transition: transform 0.3s ease-in-out !important;
+    opacity: 0.3 !important;
+    pointer-events: none !important;
   }
 
   /* Sidebar when opened via :checked state */

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -173,7 +173,7 @@ a:hover {
     font-weight: 600;
 }
 
-/* Sidebar */
+/* Sidebar - Desktop default, mobile overridden by mobile-responsive.css */
 .book-sidebar {
     position: fixed;
     top: var(--header-height);
@@ -184,7 +184,7 @@ a:hover {
     border-right: 1px solid var(--border-color);
     overflow-y: auto;
     z-index: 900;
-    transform: translateX(0);
+    /* Remove fixed transform to allow mobile-responsive.css control */
     transition: transform 0.3s ease;
 }
 

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -15,7 +15,7 @@
    ============================================ */
 
 @media (min-width: 768px) {
-  /* Reset sidebar to normal desktop behavior */
+  /* Force sidebar to normal desktop behavior - override all mobile styles */
   .book-sidebar {
     position: fixed !important;
     transform: translateX(0) !important;
@@ -24,6 +24,7 @@
     box-shadow: none !important;
     opacity: 1 !important;
     pointer-events: auto !important;
+    display: block !important;
   }
   
   /* Hide hamburger menu on desktop */
@@ -34,12 +35,14 @@
   /* Hide overlay on desktop */
   .book-sidebar-overlay {
     display: none !important;
+    visibility: hidden !important;
   }
   
-  /* Reset checkbox effect on desktop */
+  /* Force checkbox effect to have no impact on desktop */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
     background: var(--bg-primary) !important;
+    opacity: 1 !important;
   }
 }
 
@@ -48,21 +51,23 @@
    ============================================ */
 
 @media (max-width: 767px) {
-  /* Mobile sidebar - default hidden state */
+  /* Mobile sidebar - FORCE hidden state by default */
   .book-sidebar {
-    display: block;
-    position: fixed;
-    top: var(--header-height, 60px);
-    left: 0;
-    width: 280px;
-    height: calc(100vh - var(--header-height, 60px));
-    background: transparent;
-    border-right: none;
-    padding: 1rem;
-    overflow-y: auto;
-    z-index: 1000;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease-in-out;
+    display: block !important;
+    position: fixed !important;
+    top: var(--header-height, 60px) !important;
+    left: 0 !important;
+    width: 280px !important;
+    height: calc(100vh - var(--header-height, 60px)) !important;
+    background: transparent !important;
+    border-right: none !important;
+    padding: 1rem !important;
+    overflow-y: auto !important;
+    z-index: 1000 !important;
+    transform: translateX(-100%) !important;
+    transition: transform 0.3s ease-in-out !important;
+    opacity: 0.3 !important;
+    pointer-events: none !important;
   }
 
   /* Sidebar when opened via :checked state */


### PR DESCRIPTION
## サイドナビゲーション常時表示とグレーアウトトグル問題の根本修正

**問題**:
- サイドナビゲーションが常時表示されたまま
- ハンバーガーメニューで「非表示⇔表示」ではなく「有効⇔グレーアウト」の切り替えのみ

## 根本原因特定

### CSS Transform 競合


main.cssの固定transformがmobile-responsive.cssを上書きして、モバイルで隠れない状態になっていた。

## 解決策

### 1. main.cssからTransform競合を削除


### 2. モバイル非表示を最強化


### 3. デスクトップ表示を保証


## 修正後の期待動作

### デスクトップ (768px+):
- ✅ サイドバー常時表示（通常動作）
- ✅ ハンバーガーメニュー非表示

### モバイル (767px-):
- ✅ **デフォルト**: サイドバー完全非表示 (translateX(-100%))
- ✅ **ハンバーガーON**: サイドバーがスライドイン (translateX(0))
- ✅ **ハンバーガーOFF**: サイドバーがスライドアウト (translateX(-100%))

正しい「非表示⇔表示」の切り替え動作になります。

🤖 Generated with [Claude Code](https://claude.ai/code)