### PR TITLE
fix: restore mobile main content width to fit screen

### DIFF
--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -316,6 +316,61 @@
     margin: 0;
   }
 
+  /* Fix main content width for mobile - remove sidebar margin */
+  .book-main {
+    margin-left: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  /* Ensure content fits mobile screen width */
+  .book-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1rem !important;
+    margin: 0 !important;
+  }
+
+  /* Ensure page content fits mobile */
+  .page-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1rem !important;
+    margin: 0 !important;
+    box-sizing: border-box !important;
+  }
+
+  /* Fix any container width issues */
+  .book-layout,
+  .book-main,
+  .book-content,
+  article,
+  section,
+  div {
+    max-width: 100% !important;
+    overflow-x: hidden !important;
+  }
+}
+
+/* Print Styles */
+@media print {
+  .book-header,
+  .book-sidebar,
+  .edit-page,
+  .page-navigation {
+    display: none;
+  }
+  
+  .book-main {
+    margin: 0;
+  }
+  
+  .book-content {
+    max-width: 100%;
+    padding: 0;
+    margin: 0;
+  }
+
   .page-content {
     font-size: 12pt;
     line-height: 1.4;

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -316,6 +316,61 @@
     margin: 0;
   }
 
+  /* Fix main content width for mobile - remove sidebar margin */
+  .book-main {
+    margin-left: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  /* Ensure content fits mobile screen width */
+  .book-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1rem !important;
+    margin: 0 !important;
+  }
+
+  /* Ensure page content fits mobile */
+  .page-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1rem !important;
+    margin: 0 !important;
+    box-sizing: border-box !important;
+  }
+
+  /* Fix any container width issues */
+  .book-layout,
+  .book-main,
+  .book-content,
+  article,
+  section,
+  div {
+    max-width: 100% !important;
+    overflow-x: hidden !important;
+  }
+}
+
+/* Print Styles */
+@media print {
+  .book-header,
+  .book-sidebar,
+  .edit-page,
+  .page-navigation {
+    display: none;
+  }
+  
+  .book-main {
+    margin: 0;
+  }
+  
+  .book-content {
+    max-width: 100%;
+    padding: 0;
+    margin: 0;
+  }
+
   .page-content {
     font-size: 12pt;
     line-height: 1.4;


### PR DESCRIPTION
## モバイルメイン画面の幅フィット問題修正

**問題**: ハンバーガーメニュー修正後、メイン画面がスマホの幅にフィットしなくなった
- サイドバーのマージンがモバイルでも適用されたまま
- コンテンツ領域が圧縮されて横スクロールまたは切れる
- スマホ表示で使い勝手が悪い

## 原因分析
サイドバー修正時にのmain.css設定が影響:


モバイルでサイドバーが隠れても、メインコンテンツ領域に280pxのマージンが残り、画面幅を圧迫していた。

## 修正内容

### 1. モバイルでサイドバーマージン削除


### 2. コンテンツ領域の最適化


### 3. 全コンテナの幅制御


## 修正結果

### モバイル (767px以下):
- ✅ **メイン画面**: スマホ幅にピッタリフィット
- ✅ **ハンバーガーメニュー**: 正常動作（前回修正済み）
- ✅ **横スクロール**: 完全に防止
- ✅ **パディング**: モバイル最適化（1rem）

### デスクトップ (768px以上):
- ✅ **レイアウト**: 変更なし（通常動作）
- ✅ **サイドバー**: 常時表示
- ✅ **メインコンテンツ**: サイドバー分のマージン維持

🤖 Generated with [Claude Code](https://claude.ai/code)