### PR TITLE
fix: resolve left margin space on tablet screen sizes

### DIFF
--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -11,11 +11,83 @@
 }
 
 /* ============================================
-   Desktop View (768px and above) - Reset mobile styles
+   Tablet View (768px - 1024px) - Use hamburger menu
    ============================================ */
 
-@media (min-width: 768px) {
-  /* Force sidebar to normal desktop behavior - override all mobile styles */
+@media (min-width: 768px) and (max-width: 1024px) {
+  /* Tablet: Use hamburger menu like mobile */
+  
+  /* Show hamburger menu on tablet */
+  .sidebar-toggle {
+    display: flex !important;
+  }
+  
+  /* Tablet sidebar - default hidden state */
+  .book-sidebar {
+    position: fixed !important;
+    top: var(--header-height, 60px) !important;
+    left: 0 !important;
+    width: 280px !important;
+    height: calc(100vh - var(--header-height, 60px)) !important;
+    background: transparent !important;
+    border-right: none !important;
+    padding: 1rem !important;
+    overflow-y: auto !important;
+    z-index: 1000 !important;
+    transform: translateX(-100%) !important;
+    transition: transform 0.3s ease-in-out !important;
+    opacity: 0.3 !important;
+    pointer-events: none !important;
+  }
+  
+  /* Tablet sidebar when opened via :checked state */
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
+    transform: translateX(0) !important;
+    background: #f9fafb !important;
+    background-color: #f9fafb !important;
+    border-right: 1px solid #e5e7eb !important;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) !important;
+    pointer-events: auto !important;
+    z-index: 1000 !important;
+    opacity: 1 !important;
+  }
+  
+  /* Remove sidebar margin from main content on tablet */
+  .book-main {
+    margin-left: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+  
+  /* Show overlay on tablet */
+  .book-sidebar-overlay {
+    display: block !important;
+    visibility: visible !important;
+  }
+  
+  /* Ensure tablet content fits screen width */
+  .book-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1.5rem !important;
+    margin: 0 !important;
+  }
+  
+  .page-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1.5rem !important;
+    margin: 0 !important;
+    box-sizing: border-box !important;
+  }
+}
+
+/* ============================================
+   Desktop View (1025px and above) - Normal sidebar
+   ============================================ */
+
+@media (min-width: 1025px) {
+  /* Force sidebar to normal desktop behavior */
   .book-sidebar {
     position: fixed !important;
     transform: translateX(0) !important;
@@ -43,6 +115,11 @@
     transform: translateX(0) !important;
     background: var(--bg-primary) !important;
     opacity: 1 !important;
+  }
+  
+  /* Ensure main content has proper sidebar margin on desktop */
+  .book-main {
+    margin-left: var(--sidebar-width) !important;
   }
 }
 

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -11,11 +11,83 @@
 }
 
 /* ============================================
-   Desktop View (768px and above) - Reset mobile styles
+   Tablet View (768px - 1024px) - Use hamburger menu
    ============================================ */
 
-@media (min-width: 768px) {
-  /* Force sidebar to normal desktop behavior - override all mobile styles */
+@media (min-width: 768px) and (max-width: 1024px) {
+  /* Tablet: Use hamburger menu like mobile */
+  
+  /* Show hamburger menu on tablet */
+  .sidebar-toggle {
+    display: flex !important;
+  }
+  
+  /* Tablet sidebar - default hidden state */
+  .book-sidebar {
+    position: fixed !important;
+    top: var(--header-height, 60px) !important;
+    left: 0 !important;
+    width: 280px !important;
+    height: calc(100vh - var(--header-height, 60px)) !important;
+    background: transparent !important;
+    border-right: none !important;
+    padding: 1rem !important;
+    overflow-y: auto !important;
+    z-index: 1000 !important;
+    transform: translateX(-100%) !important;
+    transition: transform 0.3s ease-in-out !important;
+    opacity: 0.3 !important;
+    pointer-events: none !important;
+  }
+  
+  /* Tablet sidebar when opened via :checked state */
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
+    transform: translateX(0) !important;
+    background: #f9fafb !important;
+    background-color: #f9fafb !important;
+    border-right: 1px solid #e5e7eb !important;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15) !important;
+    pointer-events: auto !important;
+    z-index: 1000 !important;
+    opacity: 1 !important;
+  }
+  
+  /* Remove sidebar margin from main content on tablet */
+  .book-main {
+    margin-left: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+  
+  /* Show overlay on tablet */
+  .book-sidebar-overlay {
+    display: block !important;
+    visibility: visible !important;
+  }
+  
+  /* Ensure tablet content fits screen width */
+  .book-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1.5rem !important;
+    margin: 0 !important;
+  }
+  
+  .page-content {
+    max-width: 100% !important;
+    width: 100% !important;
+    padding: 1.5rem !important;
+    margin: 0 !important;
+    box-sizing: border-box !important;
+  }
+}
+
+/* ============================================
+   Desktop View (1025px and above) - Normal sidebar
+   ============================================ */
+
+@media (min-width: 1025px) {
+  /* Force sidebar to normal desktop behavior */
   .book-sidebar {
     position: fixed !important;
     transform: translateX(0) !important;
@@ -43,6 +115,11 @@
     transform: translateX(0) !important;
     background: var(--bg-primary) !important;
     opacity: 1 !important;
+  }
+  
+  /* Ensure main content has proper sidebar margin on desktop */
+  .book-main {
+    margin-left: var(--sidebar-width) !important;
   }
 }
 


### PR DESCRIPTION
## 画面幅を狭くした時の左側空白問題修正

**問題**: 画面サイズを狭くした時（タブレットサイズ）に左側に空白が残る
- 768px-1024pxの範囲でサイドバー用の余白が残存
- タブレット領域での適切なレイアウト制御がない
- 中間サイズでの使い勝手が悪い

## 根本原因
従来の2段階ブレークポイント:
- **767px以下**: モバイル（ハンバーガーメニュー）
- **768px以上**: デスクトップ（サイドバー常時表示）

問題: 768px-1024pxのタブレット領域で、サイドバーが表示されるがメインコンテンツのマージン調整がされず左側に空白ができる

## 解決策: 3段階レスポンシブ設計

### 1. モバイル (0-767px)


### 2. タブレット (768px-1024px) 【新設】


### 3. デスクトップ (1025px以上)


## 実装詳細

### タブレット専用CSS (768px-1024px):


### デスクトップCSS (1025px以上):


## 修正後の動作

### モバイル (≤767px):
- ✅ ハンバーガーメニュー
- ✅ 全幅コンテンツ

### タブレット (768-1024px):
- ✅ ハンバーガーメニュー
- ✅ 全幅コンテンツ
- ✅ **左側空白なし**

### デスクトップ (≥1025px):
- ✅ サイドバー常時表示
- ✅ 適切なコンテンツマージン

🤖 Generated with [Claude Code](https://claude.ai/code)