### PR TITLE
fix: force remove persistent left margin with universal CSS reset

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -279,12 +279,12 @@ a:hover {
     padding: 0.375rem 0.75rem;
 }
 
-/* Main Content */
+/* Main Content - No default margin-left, controlled by responsive CSS */
 .book-main {
     flex: 1;
-    margin-left: var(--sidebar-width);
     margin-top: var(--header-height);
     min-height: calc(100vh - var(--header-height));
+    /* margin-left removed - will be set only for desktop in mobile-responsive.css */
 }
 
 .book-content {

--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -11,6 +11,26 @@
 }
 
 /* ============================================
+   Force remove all default margins - Universal Reset
+   ============================================ */
+
+/* Remove all left margins by default - will be added back only for large desktop */
+.book-main {
+  margin-left: 0 !important;
+  width: 100% !important;
+  max-width: 100vw !important;
+}
+
+.book-content {
+  margin-left: 0 !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+  box-sizing: border-box !important;
+}
+
+/* ============================================
    Tablet View (768px - 1024px) - Use hamburger menu
    ============================================ */
 
@@ -117,9 +137,19 @@
     opacity: 1 !important;
   }
   
-  /* Ensure main content has proper sidebar margin on desktop */
+  /* ONLY on large desktop: Add sidebar margin */
   .book-main {
     margin-left: var(--sidebar-width) !important;
+    width: calc(100% - var(--sidebar-width)) !important;
+    max-width: calc(100vw - var(--sidebar-width)) !important;
+  }
+  
+  .book-content {
+    margin-left: 0 !important;
+    width: 100% !important;
+    max-width: var(--content-max-width) !important;
+    padding-left: 3rem !important;
+    padding-right: 3rem !important;
   }
 }
 

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -279,12 +279,12 @@ a:hover {
     padding: 0.375rem 0.75rem;
 }
 
-/* Main Content */
+/* Main Content - No default margin-left, controlled by responsive CSS */
 .book-main {
     flex: 1;
-    margin-left: var(--sidebar-width);
     margin-top: var(--header-height);
     min-height: calc(100vh - var(--header-height));
+    /* margin-left removed - will be set only for desktop in mobile-responsive.css */
 }
 
 .book-content {

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -11,6 +11,26 @@
 }
 
 /* ============================================
+   Force remove all default margins - Universal Reset
+   ============================================ */
+
+/* Remove all left margins by default - will be added back only for large desktop */
+.book-main {
+  margin-left: 0 !important;
+  width: 100% !important;
+  max-width: 100vw !important;
+}
+
+.book-content {
+  margin-left: 0 !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+  box-sizing: border-box !important;
+}
+
+/* ============================================
    Tablet View (768px - 1024px) - Use hamburger menu
    ============================================ */
 
@@ -117,9 +137,19 @@
     opacity: 1 !important;
   }
   
-  /* Ensure main content has proper sidebar margin on desktop */
+  /* ONLY on large desktop: Add sidebar margin */
   .book-main {
     margin-left: var(--sidebar-width) !important;
+    width: calc(100% - var(--sidebar-width)) !important;
+    max-width: calc(100vw - var(--sidebar-width)) !important;
+  }
+  
+  .book-content {
+    margin-left: 0 !important;
+    width: 100% !important;
+    max-width: var(--content-max-width) !important;
+    padding-left: 3rem !important;
+    padding-right: 3rem !important;
   }
 }
 


### PR DESCRIPTION
## 左側空白問題の根本的解決

**問題**: 前回の修正でも左側空白が残る
- タブレット・モバイルサイズで280pxの左マージンが持続
- CSS優先度の問題ででも上書きされない
- 根本原因はmain.cssのデフォルト設定

## 根本原因特定

### main.cssのデフォルト設定が元凶:


この設定がすべての画面サイズで基本として適用され、mobile-responsive.cssの上書きが不完全だった。

## 根本的解決策

### 1. main.cssからデフォルトマージン完全削除:


### 2. 全サイズで強制リセット（Universal Reset）:


### 3. デスクトップのみサイドバーマージン追加:


## アプローチの変更

**Before**: 「デフォルトでマージンあり → 条件付きで削除」
**After**: 「デフォルトでマージンなし → 大画面のみ追加」

これにより、CSS継承やカスケードの問題を根本から排除。

## 期待結果

### 全サイズ (≤1024px):
- ✅ **左マージン**: 完全に0
- ✅ **コンテンツ幅**: 画面フル活用
- ✅ **CSS継承問題**: 完全解決

### 大画面デスクトップ (≥1025px):
- ✅ **左マージン**: 280px（サイドバー分）
- ✅ **サイドバー**: 常時表示
- ✅ **適切なレイアウト**: 維持

🤖 Generated with [Claude Code](https://claude.ai/code)