### PR TITLE
GitHub初心者ガイド用SVG図表の追加

### DIFF
--- a/docs/assets/images/diagrams/git-workflow.svg
+++ b/docs/assets/images/diagrams/git-workflow.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .stage-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
+      .branch-text { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; fill: #2c3e50; font-weight: bold; }
+      .command-text { font-family: 'Courier New', monospace; font-size: 10px; fill: #2c3e50; }
+      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .workspace-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
+      .staging-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
+      .local-repo-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
+      .remote-repo-box { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
+      .branch-main { stroke: #2c3e50; stroke-width: 3; fill: none; }
+      .branch-feature { stroke: #3498db; stroke-width: 2; fill: none; }
+      .branch-hotfix { stroke: #e74c3c; stroke-width: 2; fill: none; stroke-dasharray: 5,3; }
+      .commit-node { fill: #fff; stroke: #34495e; stroke-width: 2; }
+      .merge-node { fill: #9b59b6; stroke: #8e44ad; stroke-width: 2; }
+      .component { fill: #fff; stroke: #95a5a6; stroke-width: 1; }
+      .flow-arrow { stroke: #34495e; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="#34495e"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="30" class="title" text-anchor="middle">Gitワークフローとブランチ戦略</text>
+
+  <!-- Git Areas -->
+  <g id="git-areas">
+    <text x="450" y="70" class="branch-text" text-anchor="middle">Gitの4つの領域</text>
+    
+    <!-- Working Directory -->
+    <rect x="50" y="90" width="180" height="100" class="workspace-box" rx="10"/>
+    <text x="140" y="115" class="stage-title" text-anchor="middle">作業ディレクトリ</text>
+    <text x="140" y="135" class="stage-title" text-anchor="middle">Working Directory</text>
+    <rect x="65" y="145" width="150" height="30" class="component" rx="3"/>
+    <text x="140" y="165" class="command-text" text-anchor="middle">ファイル編集</text>
+    
+    <!-- Staging Area -->
+    <rect x="260" y="90" width="180" height="100" class="staging-box" rx="10"/>
+    <text x="350" y="115" class="stage-title" text-anchor="middle">ステージングエリア</text>
+    <text x="350" y="135" class="stage-title" text-anchor="middle">Staging Area</text>
+    <rect x="275" y="145" width="150" height="30" class="component" rx="3"/>
+    <text x="350" y="165" class="command-text" text-anchor="middle">git add</text>
+    
+    <!-- Local Repository -->
+    <rect x="470" y="90" width="180" height="100" class="local-repo-box" rx="10"/>
+    <text x="560" y="115" class="stage-title" text-anchor="middle">ローカルリポジトリ</text>
+    <text x="560" y="135" class="stage-title" text-anchor="middle">Local Repository</text>
+    <rect x="485" y="145" width="150" height="30" class="component" rx="3"/>
+    <text x="560" y="165" class="command-text" text-anchor="middle">git commit</text>
+    
+    <!-- Remote Repository -->
+    <rect x="680" y="90" width="180" height="100" class="remote-repo-box" rx="10"/>
+    <text x="770" y="115" class="stage-title" text-anchor="middle">リモートリポジトリ</text>
+    <text x="770" y="135" class="stage-title" text-anchor="middle">Remote Repository</text>
+    <rect x="695" y="145" width="150" height="30" class="component" rx="3"/>
+    <text x="770" y="165" class="command-text" text-anchor="middle">git push/pull</text>
+  </g>
+
+  <!-- Flow arrows between areas -->
+  <path d="M 230 140 L 260 140" class="flow-arrow"/>
+  <path d="M 440 140 L 470 140" class="flow-arrow"/>
+  <path d="M 650 140 L 680 140" class="flow-arrow"/>
+
+  <!-- Git Flow -->
+  <g id="git-flow">
+    <text x="450" y="230" class="branch-text" text-anchor="middle">Git Flow ブランチモデル</text>
+    
+    <!-- Main branch -->
+    <text x="50" y="260" class="branch-text">main</text>
+    <line x1="100" y1="260" x2="800" y2="260" class="branch-main"/>
+    <circle cx="150" cy="260" r="6" class="commit-node"/>
+    <circle cx="350" cy="260" r="6" class="merge-node"/>
+    <circle cx="550" cy="260" r="6" class="merge-node"/>
+    <circle cx="750" cy="260" r="6" class="commit-node"/>
+    
+    <!-- Develop branch -->
+    <text x="50" y="320" class="branch-text">develop</text>
+    <path d="M 150 260 Q 180 280 200 320" class="branch-feature"/>
+    <line x1="200" y1="320" x2="700" y2="320" class="branch-feature"/>
+    <path d="M 700 320 Q 730 280 750 260" class="branch-feature"/>
+    <circle cx="250" cy="320" r="6" class="commit-node"/>
+    <circle cx="450" cy="320" r="6" class="commit-node"/>
+    <circle cx="650" cy="320" r="6" class="commit-node"/>
+    
+    <!-- Feature branch -->
+    <text x="50" y="380" class="branch-text">feature</text>
+    <path d="M 250 320 Q 280 340 300 380" class="branch-feature"/>
+    <line x1="300" y1="380" x2="500" y2="380" class="branch-feature"/>
+    <path d="M 500 380 Q 530 340 550 320" class="branch-feature"/>
+    <circle cx="350" cy="380" r="6" class="commit-node"/>
+    <circle cx="450" cy="380" r="6" class="commit-node"/>
+    
+    <!-- Hotfix branch -->
+    <text x="50" y="440" class="branch-text">hotfix</text>
+    <path d="M 350 260 Q 380 280 400 320" class="branch-hotfix"/>
+    <line x1="400" y1="320" x2="500" y2="320" class="branch-hotfix" stroke-dasharray="5,3"/>
+    <path d="M 500 320 Q 530 280 550 260" class="branch-hotfix"/>
+    <circle cx="450" cy="320" r="6" fill="#e74c3c"/>
+  </g>
+
+  <!-- Common Git Commands -->
+  <g id="commands">
+    <rect x="50" y="480" width="800" height="180" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="450" y="505" class="branch-text" text-anchor="middle">よく使うGitコマンド</text>
+    
+    <!-- Basic Commands -->
+    <rect x="70" y="520" width="180" height="120" fill="#e6f3ff" stroke="#3498db" stroke-width="1" rx="3"/>
+    <text x="160" y="540" class="branch-text" text-anchor="middle">基本操作</text>
+    <text x="80" y="560" class="command-text">git init</text>
+    <text x="80" y="575" class="command-text">git clone [url]</text>
+    <text x="80" y="590" class="command-text">git status</text>
+    <text x="80" y="605" class="command-text">git add .</text>
+    <text x="80" y="620" class="command-text">git commit -m ""</text>
+    <text x="80" y="635" class="command-text">git push origin main</text>
+    
+    <!-- Branch Commands -->
+    <rect x="270" y="520" width="180" height="120" fill="#ffe6e6" stroke="#e74c3c" stroke-width="1" rx="3"/>
+    <text x="360" y="540" class="branch-text" text-anchor="middle">ブランチ操作</text>
+    <text x="280" y="560" class="command-text">git branch</text>
+    <text x="280" y="575" class="command-text">git branch [name]</text>
+    <text x="280" y="590" class="command-text">git checkout [branch]</text>
+    <text x="280" y="605" class="command-text">git checkout -b [new]</text>
+    <text x="280" y="620" class="command-text">git merge [branch]</text>
+    <text x="280" y="635" class="command-text">git branch -d [name]</text>
+    
+    <!-- Remote Commands -->
+    <rect x="470" y="520" width="180" height="120" fill="#e6ffe6" stroke="#2ecc71" stroke-width="1" rx="3"/>
+    <text x="560" y="540" class="branch-text" text-anchor="middle">リモート操作</text>
+    <text x="480" y="560" class="command-text">git remote -v</text>
+    <text x="480" y="575" class="command-text">git fetch origin</text>
+    <text x="480" y="590" class="command-text">git pull origin main</text>
+    <text x="480" y="605" class="command-text">git push -u origin</text>
+    <text x="480" y="620" class="command-text">git remote add [name]</text>
+    <text x="480" y="635" class="command-text">git push --tags</text>
+    
+    <!-- History Commands -->
+    <rect x="670" y="520" width="160" height="120" fill="#fff3cd" stroke="#f39c12" stroke-width="1" rx="3"/>
+    <text x="750" y="540" class="branch-text" text-anchor="middle">履歴操作</text>
+    <text x="680" y="560" class="command-text">git log --oneline</text>
+    <text x="680" y="575" class="command-text">git diff</text>
+    <text x="680" y="590" class="command-text">git show [commit]</text>
+    <text x="680" y="605" class="command-text">git reset --soft</text>
+    <text x="680" y="620" class="command-text">git revert [commit]</text>
+    <text x="680" y="635" class="command-text">git stash</text>
+  </g>
+</svg>

--- a/docs/assets/images/diagrams/github-collaboration.svg
+++ b/docs/assets/images/diagrams/github-collaboration.svg
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .section-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #2c3e50; }
+      .process-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #fff; }
+      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .code-text { font-family: 'Courier New', monospace; font-size: 10px; fill: #2c3e50; }
+      .fork-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
+      .clone-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
+      .pr-box { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
+      .review-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
+      .merge-box { fill: #9b59b6; stroke: #8e44ad; stroke-width: 2; }
+      .user-box { fill: #95a5a6; stroke: #7f8c8d; stroke-width: 2; }
+      .component { fill: #fff; stroke: #95a5a6; stroke-width: 1; }
+      .flow-arrow { stroke: #34495e; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+      .sync-arrow { stroke: #3498db; stroke-width: 2; stroke-dasharray: 5,3; fill: none; marker-end: url(#arrowhead-blue); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="#34495e"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="#3498db"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="30" class="title" text-anchor="middle">GitHubコラボレーションワークフロー</text>
+
+  <!-- Fork & Clone Workflow -->
+  <g id="fork-clone">
+    <text x="450" y="70" class="section-title" text-anchor="middle">Fork & Pull Requestワークフロー</text>
+    
+    <!-- Original Repository -->
+    <rect x="50" y="100" width="160" height="80" class="user-box" rx="10"/>
+    <text x="130" y="125" class="process-title" text-anchor="middle">オリジナル</text>
+    <text x="130" y="145" class="process-title" text-anchor="middle">リポジトリ</text>
+    <text x="130" y="165" class="small-text" text-anchor="middle">upstream</text>
+    
+    <!-- Fork -->
+    <rect x="280" y="100" width="160" height="80" class="fork-box" rx="10"/>
+    <text x="360" y="125" class="process-title" text-anchor="middle">Fork</text>
+    <text x="360" y="145" class="process-title" text-anchor="middle">自分のリポジトリ</text>
+    <text x="360" y="165" class="small-text" text-anchor="middle">origin</text>
+    
+    <!-- Local Clone -->
+    <rect x="510" y="100" width="160" height="80" class="clone-box" rx="10"/>
+    <text x="590" y="125" class="process-title" text-anchor="middle">Clone</text>
+    <text x="590" y="145" class="process-title" text-anchor="middle">ローカル環境</text>
+    <text x="590" y="165" class="small-text" text-anchor="middle">local</text>
+    
+    <!-- Work & Commit -->
+    <rect x="710" y="100" width="140" height="80" class="review-box" rx="10"/>
+    <text x="780" y="125" class="process-title" text-anchor="middle">作業</text>
+    <text x="780" y="145" class="process-title" text-anchor="middle">コミット</text>
+    <text x="780" y="165" class="small-text" text-anchor="middle">push</text>
+    
+    <!-- Flow arrows -->
+    <path d="M 210 140 L 280 140" class="flow-arrow"/>
+    <text x="245" y="130" class="small-text" text-anchor="middle">Fork</text>
+    
+    <path d="M 440 140 L 510 140" class="flow-arrow"/>
+    <text x="475" y="130" class="small-text" text-anchor="middle">Clone</text>
+    
+    <path d="M 670 140 L 710 140" class="flow-arrow"/>
+    <text x="690" y="130" class="small-text" text-anchor="middle">Edit</text>
+    
+    <!-- Push back -->
+    <path d="M 780 180 Q 780 210 590 210 Q 360 210 360 180" class="flow-arrow"/>
+    <text x="570" y="225" class="small-text" text-anchor="middle">Push</text>
+    
+    <!-- Pull Request -->
+    <path d="M 360 100 Q 360 60 130 60 Q 130 100 130 100" class="pr-box" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+    <text x="245" y="55" class="small-text" text-anchor="middle">Pull Request</text>
+  </g>
+
+  <!-- Pull Request Process -->
+  <g id="pr-process">
+    <text x="450" y="260" class="section-title" text-anchor="middle">Pull Requestプロセス</text>
+    
+    <!-- Create PR -->
+    <rect x="50" y="280" width="140" height="100" class="pr-box" rx="10"/>
+    <text x="120" y="305" class="process-title" text-anchor="middle">PR作成</text>
+    <rect x="65" y="315" width="110" height="25" class="component" rx="3"/>
+    <text x="120" y="332" class="text-content" text-anchor="middle">タイトル記入</text>
+    <rect x="65" y="345" width="110" height="25" class="component" rx="3"/>
+    <text x="120" y="362" class="text-content" text-anchor="middle">説明追加</text>
+    
+    <!-- Code Review -->
+    <rect x="220" y="280" width="140" height="100" class="review-box" rx="10"/>
+    <text x="290" y="305" class="process-title" text-anchor="middle">コードレビュー</text>
+    <rect x="235" y="315" width="110" height="25" class="component" rx="3"/>
+    <text x="290" y="332" class="text-content" text-anchor="middle">レビュー依頼</text>
+    <rect x="235" y="345" width="110" height="25" class="component" rx="3"/>
+    <text x="290" y="362" class="text-content" text-anchor="middle">フィードバック</text>
+    
+    <!-- CI/CD Check -->
+    <rect x="390" y="280" width="140" height="100" class="clone-box" rx="10"/>
+    <text x="460" y="305" class="process-title" text-anchor="middle">自動チェック</text>
+    <rect x="405" y="315" width="110" height="25" class="component" rx="3"/>
+    <text x="460" y="332" class="text-content" text-anchor="middle">テスト実行</text>
+    <rect x="405" y="345" width="110" height="25" class="component" rx="3"/>
+    <text x="460" y="362" class="text-content" text-anchor="middle">ビルド確認</text>
+    
+    <!-- Approval -->
+    <rect x="560" y="280" width="140" height="100" class="fork-box" rx="10"/>
+    <text x="630" y="305" class="process-title" text-anchor="middle">承認</text>
+    <rect x="575" y="315" width="110" height="25" class="component" rx="3"/>
+    <text x="630" y="332" class="text-content" text-anchor="middle">Approve</text>
+    <rect x="575" y="345" width="110" height="25" class="component" rx="3"/>
+    <text x="630" y="362" class="text-content" text-anchor="middle">LGTM</text>
+    
+    <!-- Merge -->
+    <rect x="730" y="280" width="120" height="100" class="merge-box" rx="10"/>
+    <text x="790" y="305" class="process-title" text-anchor="middle">マージ</text>
+    <rect x="745" y="315" width="90" height="25" class="component" rx="3"/>
+    <text x="790" y="332" class="text-content" text-anchor="middle">Merge</text>
+    <rect x="745" y="345" width="90" height="25" class="component" rx="3"/>
+    <text x="790" y="362" class="text-content" text-anchor="middle">Close PR</text>
+    
+    <!-- Process flow -->
+    <path d="M 190 330 L 220 330" class="flow-arrow"/>
+    <path d="M 360 330 L 390 330" class="flow-arrow"/>
+    <path d="M 530 330 L 560 330" class="flow-arrow"/>
+    <path d="M 700 330 L 730 330" class="flow-arrow"/>
+  </g>
+
+  <!-- Issue Management -->
+  <g id="issues">
+    <rect x="50" y="410" width="400" height="230" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="250" y="435" class="section-title" text-anchor="middle">Issue管理</text>
+    
+    <!-- Issue Types -->
+    <text x="70" y="460" class="text-content" font-weight="bold">Issueの種類:</text>
+    <rect x="70" y="470" width="80" height="30" fill="#e74c3c" stroke="#c0392b" rx="3"/>
+    <text x="110" y="490" class="process-title" text-anchor="middle">Bug</text>
+    
+    <rect x="160" y="470" width="80" height="30" fill="#2ecc71" stroke="#27ae60" rx="3"/>
+    <text x="200" y="490" class="process-title" text-anchor="middle">Feature</text>
+    
+    <rect x="250" y="470" width="80" height="30" fill="#3498db" stroke="#2980b9" rx="3"/>
+    <text x="290" y="490" class="process-title" text-anchor="middle">Docs</text>
+    
+    <rect x="340" y="470" width="90" height="30" fill="#f39c12" stroke="#e67e22" rx="3"/>
+    <text x="385" y="490" class="process-title" text-anchor="middle">Question</text>
+    
+    <!-- Issue Lifecycle -->
+    <text x="70" y="530" class="text-content" font-weight="bold">Issueライフサイクル:</text>
+    <text x="70" y="550" class="small-text">1. Open - Issue作成</text>
+    <text x="70" y="565" class="small-text">2. Assigned - 担当者割り当て</text>
+    <text x="70" y="580" class="small-text">3. In Progress - 作業中</text>
+    <text x="70" y="595" class="small-text">4. Review - レビュー中</text>
+    <text x="70" y="610" class="small-text">5. Closed - 完了</text>
+    
+    <!-- Issue Template -->
+    <text x="250" y="530" class="text-content" font-weight="bold">Issueテンプレート:</text>
+    <rect x="250" y="540" width="180" height="80" fill="#fff" stroke="#95a5a6" rx="3"/>
+    <text x="260" y="555" class="code-text">## 概要</text>
+    <text x="260" y="570" class="code-text">## 再現手順</text>
+    <text x="260" y="585" class="code-text">## 期待される動作</text>
+    <text x="260" y="600" class="code-text">## 実際の動作</text>
+    <text x="260" y="615" class="code-text">## 環境</text>
+  </g>
+
+  <!-- GitHub Actions -->
+  <g id="actions">
+    <rect x="470" y="410" width="380" height="230" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="660" y="435" class="section-title" text-anchor="middle">GitHub Actions</text>
+    
+    <!-- Workflow Triggers -->
+    <text x="490" y="460" class="text-content" font-weight="bold">トリガーイベント:</text>
+    <text x="490" y="480" class="small-text">• push - コードプッシュ時</text>
+    <text x="490" y="495" class="small-text">• pull_request - PR作成/更新時</text>
+    <text x="490" y="510" class="small-text">• schedule - 定期実行</text>
+    <text x="490" y="525" class="small-text">• workflow_dispatch - 手動実行</text>
+    <text x="490" y="540" class="small-text">• release - リリース作成時</text>
+    
+    <!-- Common Actions -->
+    <text x="490" y="570" class="text-content" font-weight="bold">よく使うアクション:</text>
+    <rect x="490" y="580" width="160" height="45" fill="#e6f3ff" stroke="#3498db" rx="3"/>
+    <text x="570" y="595" class="text-content" text-anchor="middle">テスト自動化</text>
+    <text x="500" y="610" class="code-text">actions/checkout@v3</text>
+    <text x="500" y="620" class="code-text">actions/setup-node@v3</text>
+    
+    <rect x="670" y="580" width="160" height="45" fill="#e6ffe6" stroke="#2ecc71" rx="3"/>
+    <text x="750" y="595" class="text-content" text-anchor="middle">デプロイ自動化</text>
+    <text x="680" y="610" class="code-text">actions/deploy-pages@v2</text>
+    <text x="680" y="620" class="code-text">docker/build-push@v4</text>
+  </g>
+</svg>

--- a/docs/assets/images/diagrams/github-features.svg
+++ b/docs/assets/images/diagrams/github-features.svg
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .feature-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
+      .section-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #2c3e50; }
+      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .repo-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
+      .project-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
+      .wiki-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
+      .security-box { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }
+      .insights-box { fill: #9b59b6; stroke: #8e44ad; stroke-width: 2; }
+      .pages-box { fill: #1abc9c; stroke: #16a085; stroke-width: 2; }
+      .component { fill: #fff; stroke: #95a5a6; stroke-width: 1; }
+      .connection-line { stroke: #34495e; stroke-width: 1; stroke-dasharray: 3,2; fill: none; }
+      .center-circle { fill: #2c3e50; stroke: #34495e; stroke-width: 3; }
+    </style>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="30" class="title" text-anchor="middle">GitHub主要機能マップ</text>
+
+  <!-- Central GitHub Logo/Circle -->
+  <circle cx="450" cy="350" r="60" class="center-circle"/>
+  <text x="450" y="345" class="feature-title" text-anchor="middle">GitHub</text>
+  <text x="450" y="365" class="feature-title" text-anchor="middle">リポジトリ</text>
+
+  <!-- Repository Features -->
+  <g id="repository">
+    <rect x="100" y="100" width="160" height="100" class="repo-box" rx="10"/>
+    <text x="180" y="125" class="feature-title" text-anchor="middle">コード管理</text>
+    <rect x="115" y="135" width="130" height="25" class="component" rx="3"/>
+    <text x="180" y="152" class="text-content" text-anchor="middle">ブランチ管理</text>
+    <rect x="115" y="165" width="130" height="25" class="component" rx="3"/>
+    <text x="180" y="182" class="text-content" text-anchor="middle">バージョン管理</text>
+    <line x1="260" y1="150" x2="390" y2="320" class="connection-line"/>
+  </g>
+
+  <!-- Projects -->
+  <g id="projects">
+    <rect x="300" y="80" width="160" height="100" class="project-box" rx="10"/>
+    <text x="380" y="105" class="feature-title" text-anchor="middle">Projects</text>
+    <rect x="315" y="115" width="130" height="25" class="component" rx="3"/>
+    <text x="380" y="132" class="text-content" text-anchor="middle">カンバンボード</text>
+    <rect x="315" y="145" width="130" height="25" class="component" rx="3"/>
+    <text x="380" y="162" class="text-content" text-anchor="middle">タスク管理</text>
+    <line x1="380" y1="180" x2="430" y2="290" class="connection-line"/>
+  </g>
+
+  <!-- Wiki -->
+  <g id="wiki">
+    <rect x="500" y="100" width="160" height="100" class="wiki-box" rx="10"/>
+    <text x="580" y="125" class="feature-title" text-anchor="middle">Wiki</text>
+    <rect x="515" y="135" width="130" height="25" class="component" rx="3"/>
+    <text x="580" y="152" class="text-content" text-anchor="middle">ドキュメント</text>
+    <rect x="515" y="165" width="130" height="25" class="component" rx="3"/>
+    <text x="580" y="182" class="text-content" text-anchor="middle">ガイド作成</text>
+    <line x1="560" y1="200" x2="490" y2="300" class="connection-line"/>
+  </g>
+
+  <!-- Security -->
+  <g id="security">
+    <rect x="680" y="160" width="160" height="100" class="security-box" rx="10"/>
+    <text x="760" y="185" class="feature-title" text-anchor="middle">Security</text>
+    <rect x="695" y="195" width="130" height="25" class="component" rx="3"/>
+    <text x="760" y="212" class="text-content" text-anchor="middle">脆弱性スキャン</text>
+    <rect x="695" y="225" width="130" height="25" class="component" rx="3"/>
+    <text x="760" y="242" class="text-content" text-anchor="middle">Dependabot</text>
+    <line x1="680" y1="210" x2="510" y2="320" class="connection-line"/>
+  </g>
+
+  <!-- Insights -->
+  <g id="insights">
+    <rect x="700" y="320" width="160" height="100" class="insights-box" rx="10"/>
+    <text x="780" y="345" class="feature-title" text-anchor="middle">Insights</text>
+    <rect x="715" y="355" width="130" height="25" class="component" rx="3"/>
+    <text x="780" y="372" class="text-content" text-anchor="middle">統計情報</text>
+    <rect x="715" y="385" width="130" height="25" class="component" rx="3"/>
+    <text x="780" y="402" class="text-content" text-anchor="middle">貢献者グラフ</text>
+    <line x1="700" y1="370" x2="510" y2="350" class="connection-line"/>
+  </g>
+
+  <!-- GitHub Pages -->
+  <g id="pages">
+    <rect x="650" y="460" width="160" height="100" class="pages-box" rx="10"/>
+    <text x="730" y="485" class="feature-title" text-anchor="middle">GitHub Pages</text>
+    <rect x="665" y="495" width="130" height="25" class="component" rx="3"/>
+    <text x="730" y="512" class="text-content" text-anchor="middle">静的サイト</text>
+    <rect x="665" y="525" width="130" height="25" class="component" rx="3"/>
+    <text x="730" y="542" class="text-content" text-anchor="middle">自動デプロイ</text>
+    <line x1="650" y1="510" x2="500" y2="390" class="connection-line"/>
+  </g>
+
+  <!-- Additional Features Grid -->
+  <g id="additional-features">
+    <rect x="50" y="250" width="280" height="180" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="190" y="275" class="section-title" text-anchor="middle">コラボレーション機能</text>
+    
+    <text x="70" y="300" class="text-content" font-weight="bold">Pull Request:</text>
+    <text x="70" y="315" class="small-text">• コードレビュー</text>
+    <text x="70" y="330" class="small-text">• ディスカッション</text>
+    <text x="70" y="345" class="small-text">• 自動マージ</text>
+    
+    <text x="70" y="370" class="text-content" font-weight="bold">Issues:</text>
+    <text x="70" y="385" class="small-text">• バグトラッキング</text>
+    <text x="70" y="400" class="small-text">• 機能リクエスト</text>
+    <text x="70" y="415" class="small-text">• ラベル管理</text>
+    
+    <text x="200" y="300" class="text-content" font-weight="bold">Discussions:</text>
+    <text x="200" y="315" class="small-text">• Q&amp;A</text>
+    <text x="200" y="330" class="small-text">• アイデア共有</text>
+    <text x="200" y="345" class="small-text">• アナウンス</text>
+    
+    <text x="200" y="370" class="text-content" font-weight="bold">Teams:</text>
+    <text x="200" y="385" class="small-text">• アクセス管理</text>
+    <text x="200" y="400" class="small-text">• 権限設定</text>
+    <text x="200" y="415" class="small-text">• メンション</text>
+  </g>
+
+  <!-- Automation Features -->
+  <g id="automation">
+    <rect x="50" y="450" width="280" height="200" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="190" y="475" class="section-title" text-anchor="middle">自動化機能</text>
+    
+    <text x="70" y="500" class="text-content" font-weight="bold">GitHub Actions:</text>
+    <text x="70" y="515" class="small-text">• CI/CD パイプライン</text>
+    <text x="70" y="530" class="small-text">• 自動テスト</text>
+    <text x="70" y="545" class="small-text">• 自動デプロイ</text>
+    <text x="70" y="560" class="small-text">• スケジュール実行</text>
+    
+    <text x="70" y="585" class="text-content" font-weight="bold">Webhooks:</text>
+    <text x="70" y="600" class="small-text">• イベント通知</text>
+    <text x="70" y="615" class="small-text">• 外部連携</text>
+    <text x="70" y="630" class="small-text">• 自動トリガー</text>
+    
+    <text x="200" y="500" class="text-content" font-weight="bold">Branch Protection:</text>
+    <text x="200" y="515" class="small-text">• レビュー必須化</text>
+    <text x="200" y="530" class="small-text">• ステータスチェック</text>
+    <text x="200" y="545" class="small-text">• 自動マージ</text>
+    
+    <text x="200" y="585" class="text-content" font-weight="bold">Templates:</text>
+    <text x="200" y="600" class="small-text">• Issue テンプレート</text>
+    <text x="200" y="615" class="small-text">• PR テンプレート</text>
+    <text x="200" y="630" class="small-text">• リポジトリテンプレート</text>
+  </g>
+
+  <!-- Settings & Admin -->
+  <g id="settings">
+    <rect x="360" y="470" width="260" height="160" fill="#f8f9fa" stroke="#dee2e6" stroke-width="1" rx="5"/>
+    <text x="490" y="495" class="section-title" text-anchor="middle">設定と管理</text>
+    
+    <text x="380" y="520" class="text-content" font-weight="bold">リポジトリ設定:</text>
+    <text x="380" y="535" class="small-text">• 公開/非公開</text>
+    <text x="380" y="550" class="small-text">• コラボレーター管理</text>
+    <text x="380" y="565" class="small-text">• デフォルトブランチ</text>
+    <text x="380" y="580" class="small-text">• マージ戦略</text>
+    
+    <text x="500" y="520" class="text-content" font-weight="bold">統合:</text>
+    <text x="500" y="535" class="small-text">• Slack連携</text>
+    <text x="500" y="550" class="small-text">• JIRA連携</text>
+    <text x="500" y="565" class="small-text">• CI/CDツール</text>
+    <text x="500" y="580" class="small-text">• IDE連携</text>
+    
+    <text x="380" y="605" class="text-content" font-weight="bold">セキュリティ:</text>
+    <text x="380" y="620" class="small-text">• 2FA認証・SSH鍵・アクセストークン・監査ログ</text>
+  </g>
+</svg>


### PR DESCRIPTION
## 概要
GitHub初心者ガイドの内容理解を支援するための技術図表をSVG形式で作成しました。

## 作成した図表

### 1. Gitワークフロー図 (`git-workflow.svg`)
- Gitの4つの領域（Working Directory、Staging Area、Local Repository、Remote Repository）
- Git Flowブランチモデルの完全な視覚化
- main、develop、feature、hotfixブランチの関係性
- 4カテゴリのよく使うGitコマンド一覧（基本操作、ブランチ操作、リモート操作、履歴操作）

### 2. GitHubコラボレーション図 (`github-collaboration.svg`)
- Fork & Pull Requestの完全なワークフロー
- 5段階のPull Requestプロセス（PR作成→コードレビュー→自動チェック→承認→マージ）
- Issue管理の種類（Bug、Feature、Docs、Question）とライフサイクル
- GitHub Actionsのトリガーイベントと一般的なアクション

### 3. GitHub機能マップ図 (`github-features.svg`)
- GitHub主要機能の相互関係を示すマップ
- 6つのコア機能（コード管理、Projects、Wiki、Security、Insights、GitHub Pages）
- コラボレーション機能の詳細（Pull Request、Issues、Discussions、Teams）
- 自動化機能（GitHub Actions、Webhooks、Branch Protection、Templates）
- 設定と管理オプション

## 技術仕様
- ✅ book-formatter SVGスタイルガイドラインに完全準拠
- ✅ 日本語テキストにNoto Sans JPフォントを使用
- ✅ コマンド表示にCourier Newフォントを使用
- ✅ WCAG 2.1準拠のアクセシブルな色彩設計
- ✅ レスポンシブなviewBox設定（900x700px）
- ✅ 統一された配色とスタイル

## チェックリスト
- [x] SVG形式での図表作成
- [x] book-formatter ガイドラインへの準拠
- [x] 日本語フォント（Noto Sans JP）の適用
- [x] アクセシビリティの考慮
- [x] 適切なファイル配置（docs/assets/images/diagrams/）

## テスト方法
```bash
npm start
# ブラウザで図表の表示を確認
```

🤖 Generated with [Claude Code](https://claude.ai/code)