### PR TITLE
docs: add bottom navigation to root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -96,3 +96,4 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 **📅 最終更新:** 2025年8月6日
 
 Built with [Book Publishing Template v3.0](https://github.com/itdojp/book-publishing-template2)
+{% include page-navigation.html %}


### PR DESCRIPTION
Add bottom navigation include to docs/index.md so the root page shows prev/next/home controls.