### PR TITLE
Stage2: 目次・ナビの整合（章タイトル）

### DIFF
--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -29,7 +29,7 @@
             <ul class="toc-list">
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-introduction/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-introduction' %}active{% endif %}">
-                        <span class="chapter-number">1.</span>なぜGitHubを学ぶのか
+                        <span class="chapter-number">1.</span>はじめに - なぜGitHubを学ぶのか
                     </a>
                 </li>
                 <li class="toc-item toc-chapter">
@@ -39,12 +39,12 @@
                 </li>
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-github-account-setup/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-github-account-setup' %}active{% endif %}">
-                        <span class="chapter-number">3.</span>GitHubアカウント作成と初期設定
+                        <span class="chapter-number">3.</span>初めてのリポジトリ作成
                     </a>
                 </li>
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-basic-operations/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-basic-operations' %}active{% endif %}">
-                        <span class="chapter-number">4.</span>基本操作 - push、pull、clone
+                        <span class="chapter-number">4.</span>アカウントセキュリティの基本
                     </a>
                 </li>
             </ul>
@@ -56,22 +56,22 @@
             <ul class="toc-list">
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-repository-management/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-repository-management' %}active{% endif %}">
-                        <span class="chapter-number">5.</span>リポジトリ管理の実践
+                        <span class="chapter-number">5.</span>ファイルのアップロードと管理
                     </a>
                 </li>
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-collaboration-basics/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-collaboration-basics' %}active{% endif %}">
-                        <span class="chapter-number">6.</span>チーム開発入門 - ブランチとマージ
+                        <span class="chapter-number">6.</span>GitHub Desktop の活用
                     </a>
                 </li>
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-pull-requests/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-pull-requests' %}active{% endif %}">
-                        <span class="chapter-number">7.</span>プルリクエストによるコードレビュー
+                        <span class="chapter-number">7.</span>ブランチの基本操作
                     </a>
                 </li>
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-issue-management/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-issue-management' %}active{% endif %}">
-                        <span class="chapter-number">8.</span>Issues活用による課題管理
+                        <span class="chapter-number">8.</span>Issue管理とプロジェクト管理
                     </a>
                 </li>
             </ul>
@@ -93,12 +93,12 @@
                 </li>
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-advanced-features/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-advanced-features' %}active{% endif %}">
-                        <span class="chapter-number">11.</span>実践的な活用法
+                        <span class="chapter-number">11.</span>高度な機能活用
                     </a>
                 </li>
                 <li class="toc-item toc-chapter">
                     <a href="{{ '/src/chapter-troubleshooting/' | relative_url }}" class="toc-link {% if page.url contains 'chapter-troubleshooting' %}active{% endif %}">
-                        <span class="chapter-number">12.</span>よくある問題と解決方法
+                        <span class="chapter-number">12.</span>トラブルシューティング
                     </a>
                 </li>
             </ul>

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,22 +35,22 @@ permalink: /
 
 1. **[はじめに - なぜGitHubを学ぶのか]({{ '/src/chapter-introduction/' | relative_url }})**
 2. **[Git基礎 - バージョン管理の仕組み]({{ '/src/chapter-git-basics/' | relative_url }})**
-3. **[GitHubアカウント作成と初期設定]({{ '/src/chapter-github-account-setup/' | relative_url }})**
-4. **[基本操作 - push、pull、clone]({{ '/src/chapter-basic-operations/' | relative_url }})**
+3. **[初めてのリポジトリ作成]({{ '/src/chapter-github-account-setup/' | relative_url }})**
+4. **[アカウントセキュリティの基本]({{ '/src/chapter-basic-operations/' | relative_url }})**
 
 ### 第2部: 実践編
 
-5. **[リポジトリ管理の実践]({{ '/src/chapter-repository-management/' | relative_url }})**
-6. **[チーム開発入門 - ブランチとマージ]({{ '/src/chapter-collaboration-basics/' | relative_url }})**
-7. **[プルリクエストによるコードレビュー]({{ '/src/chapter-pull-requests/' | relative_url }})**
-8. **[Issues活用による課題管理]({{ '/src/chapter-issue-management/' | relative_url }})**
+5. **[ファイルのアップロードと管理]({{ '/src/chapter-repository-management/' | relative_url }})**
+6. **[GitHub Desktop の活用]({{ '/src/chapter-collaboration-basics/' | relative_url }})**
+7. **[ブランチの基本操作]({{ '/src/chapter-pull-requests/' | relative_url }})**
+8. **[Issue管理とプロジェクト管理]({{ '/src/chapter-issue-management/' | relative_url }})**
 
 ### 第3部: 自動化・高度活用編
 
 9. **[GitHub Actions入門 - 自動化の基礎]({{ '/src/chapter-github-actions/' | relative_url }})**
 10. **[セキュリティのベストプラクティス]({{ '/src/chapter-security-best-practices/' | relative_url }})**
-11. **[実践的な活用法]({{ '/src/chapter-advanced-features/' | relative_url }})**
-12. **[よくある問題と解決方法]({{ '/src/chapter-troubleshooting/' | relative_url }})**
+11. **[高度な機能活用]({{ '/src/chapter-advanced-features/' | relative_url }})**
+12. **[トラブルシューティング]({{ '/src/chapter-troubleshooting/' | relative_url }})**
 
 ### 付録
 
@@ -97,4 +97,4 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 
 Built with [Book Publishing Template v3.0](https://github.com/itdojp/book-publishing-template2)
 {% include page-navigation.html %}
-\n<!-- trigger rebuild -->
+<!-- trigger rebuild -->


### PR DESCRIPTION
Issue: itdojp/it-engineer-knowledge-architecture#58

Stage2（構成変更 Round1）の最小差分として、目次とサイドバーの章タイトルを、現状の各章ページのタイトルに合わせて整合させました。

- 更新: `docs/index.md`
  - 目次の章名を実ページタイトルへ合わせる
  - 末尾に残っていた文字列 `\n` を除去（HTMLコメントのみ残す）
- 更新: `docs/_includes/sidebar-nav.html`
  - 目次（サイドバー）の章名を実ページタイトルへ合わせる

次の候補（本PRでは未対応）:
- 章番号（第N章）/節番号（N.x）と `order:` の整合
- 未参照ページ（`docs/src/chapter-security/` 等）の扱い整理
