### PR TITLE
fix: 付録タイトル（front matter）をH1に整合

### DIFF
--- a/docs/src/appendix-git-commands-reference/index.md
+++ b/docs/src/appendix-git-commands-reference/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Gitコマンドリファレンス"
+title: "付録A：Gitコマンドリファレンス"
 layout: book
 order: 100
 ---

--- a/docs/src/appendix-github-shortcuts/index.md
+++ b/docs/src/appendix-github-shortcuts/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GitHubショートカット集"
+title: "付録B：GitHubショートカット集"
 layout: book
 order: 101
 ---

--- a/docs/src/appendix-resources/index.md
+++ b/docs/src/appendix-resources/index.md
@@ -1,5 +1,5 @@
 ---
-title: "学習リソースと参考文献"
+title: "付録C：学習リソースと参考文献"
 layout: book
 order: 102
 ---


### PR DESCRIPTION
目的: 付録ページのタイトル表示（HTML title / ナビ）を本文H1と一致させ、導線の混乱を減らす。

対応内容:
- 付録A〜Cの `title`（front matter）を、本文先頭のH1（`付録X：...`）に合わせて更新

対象:
- `docs/src/appendix-git-commands-reference/index.md`
- `docs/src/appendix-github-shortcuts/index.md`
- `docs/src/appendix-resources/index.md`
