### PR TITLE
Stage3: polish security alerts intro

### DIFF
--- a/docs/src/chapter-security-best-practices/index.md
+++ b/docs/src/chapter-security-best-practices/index.md
@@ -107,7 +107,7 @@ const apiKey = process.env.API_KEY; // ✅ 環境変数から取得
 
 ### 依存関係の脆弱性チェック
 
-GitHubの自動セキュリティアラート：
+GitHubの自動セキュリティアラートには、次のものがあります。
 - Dependabot alerts
 - Security advisories
 - 依存関係の自動更新
@@ -177,5 +177,4 @@ git gc --prune=now --aggressive
 - 定期的なセキュリティ監査
 
 次の章では、これらのセキュリティ知識を活用した実践的なプロジェクト運用方法について学習します。
-
 


### PR DESCRIPTION
Stage3（表現・スタイル）として、箇条書き導入文を文として完結する形に整えます。

- 対象: `docs/src/chapter-security-best-practices/index.md`
- 変更: 「GitHubの自動セキュリティアラート：」を「GitHubの自動セキュリティアラートには、次のものがあります。」に修正
- 目的: ラベル用途ではない箇所の「：」終止を避け、読み進めやすさを向上（意味は変更しない）
