### PR TITLE
Fix: ナビゲーション不具合と図の表示崩れ（#8）

### DIFF
--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -74,7 +74,7 @@ display ToC titles even when order falls back to site.pages.
 {% endif %}
 
 {% if nav_items == nil or nav_items.size == 0 %}
-  {%- assign ordered_pages = site.pages | where: "layout", "book" | where_exp: "p", "p.order" | sort: "order" -%}
+  {%- assign ordered_pages = site.pages | where: "layout", "book" | where_exp: "p", "p.order and p.url contains '/src/'" | sort: "order" -%}
   {% if ordered_pages and ordered_pages.size > 0 %}
     {% assign nav_items = ordered_pages %}
   {% endif %}

--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -17,7 +17,7 @@
             <ul class="toc-list">
                 <li class="toc-item">
                     <a href="{{ '/' | relative_url }}" class="toc-link {% if page.url == '/' %}active{% endif %}">
-                        🏠 はじめに
+                        🏠 目次
                     </a>
                 </li>
             </ul>

--- a/docs/assets/images/diagrams/chapter01/02_github_ecosystem.svg
+++ b/docs/assets/images/diagrams/chapter01/02_github_ecosystem.svg
@@ -27,7 +27,7 @@
   <!-- 中央のGitHub -->
   <g class="github-core">
     <circle cx="400" cy="300" r="80" class="primary" opacity="0.8"/>
-    <circle cx="400" cy="300" r="80" class="primary-stroke"/>
+    <circle cx="400" cy="300" r="80" class="primary-stroke" fill="none"/>
     <text x="400" y="295" text-anchor="middle" class="text text-md" fill="white" style="font-weight: 600;">GitHub</text>
     <text x="400" y="315" text-anchor="middle" class="text text-sm" fill="white">コードホスティング</text>
   </g>

--- a/docs/assets/images/diagrams/chapter01/03_github_role_ecosystem.svg
+++ b/docs/assets/images/diagrams/chapter01/03_github_role_ecosystem.svg
@@ -25,7 +25,7 @@
   <text x="400" y="40" text-anchor="middle" class="text text-md">GitHubの役割とエコシステム</text>
   
   <!-- 中央のGitHub -->
-  <g class="central-github">
+  <g class="central-github" transform="translate(0, 15)">
     <circle cx="400" cy="220" r="70" class="primary" opacity="0.2"/>
     <circle cx="400" cy="220" r="70" class="primary-stroke" fill="none"/>
     <text x="400" y="205" text-anchor="middle" class="text text-md" style="font-weight: 600;">GitHub</text>


### PR DESCRIPTION
Closes #8

## 対応内容
- `page-navigation.html`: `/src/` 配下の本文ページだけを順序対象にすることで、章間の「前へ/次へ」が混線しないように修正（root/旧ディレクトリ等を除外）。
- `sidebar-nav.html`: ルートへのリンク表示を「目次」として明確化（誤解防止）。
- 図: `GitHubエコシステム` の枠線円が塗りつぶされる問題を修正（`fill="none"`）。
- 図: `GitHubの役割とエコシステム` の中央円をわずかに下げ、重なりリスクを低減。

## 補足（要確認）
- 「同じ図が複数回使用されている」点は意図（再掲/別説明）次第のため、本PRでは判断しません。
