### PR TITLE
Issue #142 P2: 付録Aをswitch/restoreに統一

### DIFF
--- a/docs/src/appendix-git-commands-reference/index.md
+++ b/docs/src/appendix-git-commands-reference/index.md
@@ -89,18 +89,20 @@ git commit --amend -m "新しいメッセージ"
 ### ファイルの取り消し・復元
 
 ```bash
-# ワーキングディレクトリの変更を取り消し
-git checkout -- <ファイル名>
+# ワーキングツリーの変更を取り消し（推奨）
+git restore <ファイル名>
 
-# ステージングから除外（変更は保持）
-git reset HEAD <ファイル名>
+# ステージングから除外（変更は保持）（推奨）
+git restore --staged <ファイル名>
 
-# 最新コミットから特定ファイルを復元
-git checkout HEAD -- <ファイル名>
+# 最新コミット（HEAD）から特定ファイルを復元（推奨）
+git restore --source HEAD -- <ファイル名>
 
-# 指定コミットから特定ファイルを復元
-git checkout <コミットハッシュ> -- <ファイル名>
+# 指定コミットから特定ファイルを復元（推奨）
+git restore --source <コミットハッシュ> -- <ファイル名>
 ```
+
+※ 古い解説では `git checkout -- <ファイル名>` の形式を見かけることがあります。現在は「ブランチ切り替え」は `git switch`、「ファイル復元」は `git restore` に分けると意図が伝わりやすくなります。
 
 ---
 
@@ -112,19 +114,17 @@ git checkout <コミットハッシュ> -- <ファイル名>
 # 新しいブランチを作成
 git branch <ブランチ名>
 
-# ブランチを作成して切り替え
-git checkout -b <ブランチ名>
+# ブランチを作成して切り替え（推奨）
+git switch -c <ブランチ名>
 
-# リモートブランチベースで作成・切り替え
-git checkout -b <ローカルブランチ名> origin/<リモートブランチ名>
+# リモートブランチベースで作成・切り替え（推奨）
+git switch -c <ローカルブランチ名> origin/<リモートブランチ名>
 
-# ブランチの切り替え
-git checkout <ブランチ名>
-
-# Git 2.23以降の新しい構文
+# 既存ブランチの切り替え（推奨）
 git switch <ブランチ名>
-git switch -c <新しいブランチ名>
 ```
+
+※ 古い解説では `git checkout -b` や `git checkout <ブランチ名>` を使う例もあります。いずれも動作しますが、本書では `git switch` を推奨形として扱います。
 
 ### ブランチの管理
 
@@ -496,7 +496,7 @@ git pull && git status
 git add -A && git commit -m "機能実装完了" && git push
 
 # ブランチ切り替え前の安全確認
-git status && git stash && git checkout main
+git status && git stash && git switch main
 ```
 
 ### デバッグ・調査用

--- a/docs/src/chapter-git-basics/index.md
+++ b/docs/src/chapter-git-basics/index.md
@@ -168,15 +168,9 @@ Update files
 
 ### 基本的なブランチ操作
 
-**新しいブランチの作成：**
+**新しいブランチの作成と切り替え（推奨）：**
 ```bash
-git branch feature-new-design
-git checkout feature-new-design
-```
-
-**または、作成と切り替えを同時に：**
-```bash
-git checkout -b feature-new-design
+git switch -c feature-new-design
 ```
 
 **ブランチの一覧確認：**
@@ -186,8 +180,10 @@ git branch
 
 **メインブランチに戻る：**
 ```bash
-git checkout main
+git switch main
 ```
+
+※ 古い解説では `git checkout` を使う例もあります。現在はブランチ切り替えに `git switch`、ファイル復元に `git restore` を使うと意図が伝わりやすくなります（付録Aも参照してください）。
 
 ### ブランチの活用例
 


### PR DESCRIPTION
Issue #142 の P2（付録Aのコマンドを推奨形へ）対応です。

## 変更点
- `git checkout` による「切替/復元」を、推奨形の `git switch` / `git restore` に整理（`docs/src/appendix-git-commands-reference/index.md`）
- 本文側（ブランチ操作の説明）も `git switch` に寄せて整合（`docs/src/chapter-git-basics/index.md`）

## 補足
- `docs/src/chapter-docs-as-code/index.md` の `git checkout -b` は、PR #145 側で `git switch -c` に統一済みです（先に #145 をマージすると全体として整合します）。

## 関連
- Issue: https://github.com/itdojp/github-guide-for-beginners-book/issues/142
