### PR TITLE
CI記述例の公式GitHub Actions参照を更新

### DIFF
--- a/manuscript/chapter-github-actions/index.md
+++ b/manuscript/chapter-github-actions/index.md
@@ -384,7 +384,7 @@ jobs:
       run: npm run build
     
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@v5
     
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v4
@@ -715,29 +715,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
     
     # Node.jsの依存関係キャッシュ
-    - name: Cache node modules
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
     
     # ビルド成果物のキャッシュ
-    - name: Cache build output
-      uses: actions/cache@v4
-      with:
-        path: ./dist
-        key: build-${{ github.sha }}
+      - name: Cache build output
+        uses: actions/cache@v4
+        with:
+          path: ./dist
+          key: build-${{ github.sha }}
     
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
 ```
 
 **並列実行の活用：**
@@ -748,28 +748,28 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: npm ci && npm run lint
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run lint
   
   test-unit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: npm ci && npm run test:unit
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run test:unit
   
   test-integration:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: npm ci && npm run test:integration
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run test:integration
   
   # 上記のジョブが全て成功したら実行
   deploy:
     needs: [lint, test-unit, test-integration]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: npm ci && npm run deploy
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run deploy
 ```
 
 ---


### PR DESCRIPTION
## 概要
- 書籍本文および関連テンプレートに残る、公式 GitHub Actions の旧メジャー参照を更新
- このPRで実際に存在する記述のみを更新（存在しない記述は変更なし）

## 対象方針
- `actions/cache@v3` -> `actions/cache@v4`
- `actions/upload-artifact@v3` -> `actions/upload-artifact@v4`
- `actions/download-artifact@v3` -> `actions/download-artifact@v4`
- `actions/upload-pages-artifact@v2|v3` -> `actions/upload-pages-artifact@v4`
- `actions/deploy-pages@v2` -> `actions/deploy-pages@v4`
- `actions/dependency-review-action@v3` -> `actions/dependency-review-action@v4`
- `actions/configure-pages@v3` -> `actions/configure-pages@v5`

## 補足
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
- 書籍の記述例・テンプレート更新が主目的です。