### PR TITLE
CI記述例の @master 参照をバージョンタグへ更新

### DIFF
--- a/manuscript/chapter-security/index.md
+++ b/manuscript/chapter-security/index.md
@@ -716,7 +716,7 @@ jobs:
     
     # Snyk による脆弱性スキャン
     - name: Run Snyk security scan
-      uses: snyk/actions/node@v1
+      uses: snyk/actions/node@v1.0.0
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残っている @master 参照を、明示バージョンタグへ更新

## 変更内容
- snyk/actions/node@master -> snyk/actions/node@v1.0.0

## 補足
- 本PRは、当該リポジトリに実在する該当記述のみを更新しています。
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102