### PR TITLE
CI記述例の追加Action参照を更新

### DIFF
--- a/manuscript/chapter-github-actions/index.md
+++ b/manuscript/chapter-github-actions/index.md
@@ -329,7 +329,7 @@ jobs:
       
     # テストカバレッジレポート
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage/lcov.info
         fail_ci_if_error: true


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例で、旧参照を更新

## 変更内容
- codecov/codecov-action@v5

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
