### PR TITLE
docs: actions/setup-node を v6 に更新

### DIFF
--- a/docs/assets/images/diagrams/github-collaboration.svg
+++ b/docs/assets/images/diagrams/github-collaboration.svg
@@ -182,7 +182,7 @@
     <rect x="490" y="580" width="160" height="45" fill="#e6f3ff" stroke="#3498db" rx="3"/>
     <text x="570" y="595" class="text-content" text-anchor="middle">テスト自動化</text>
     <text x="500" y="610" class="code-text">actions/checkout@v4</text>
-    <text x="500" y="620" class="code-text">actions/setup-node@v4</text>
+    <text x="500" y="620" class="code-text">actions/setup-node@v6</text>
     
     <rect x="670" y="580" width="160" height="45" fill="#e6ffe6" stroke="#2ecc71" rx="3"/>
     <text x="750" y="595" class="text-content" text-anchor="middle">デプロイ自動化</text>

--- a/manuscript/chapter-advanced-features/index.md
+++ b/manuscript/chapter-advanced-features/index.md
@@ -183,7 +183,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         registry-url: 'https://npm.pkg.github.com'
@@ -517,7 +517,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'

--- a/manuscript/chapter-github-actions/index.md
+++ b/manuscript/chapter-github-actions/index.md
@@ -151,7 +151,7 @@ jobs:
     
     # Node.js環境のセットアップ
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'
@@ -256,7 +256,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 ```
@@ -299,7 +299,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'
@@ -372,7 +372,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'
@@ -734,7 +734,7 @@ jobs:
           key: build-${{ github.sha }}
     
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/manuscript/chapter-security/index.md
+++ b/manuscript/chapter-security/index.md
@@ -698,7 +698,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
- manuscript と図表内の workflow 例で `actions/setup-node@v4` を `@v6` に更新
- 変更範囲はドキュメント・図表の記載のみ

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102