### PR TITLE
chore(svg): normalize font-family stacks

### DIFF
--- a/docs/assets/images/diagrams/chapter01/01_version_control_evolution.svg
+++ b/docs/assets/images/diagrams/chapter01/01_version_control_evolution.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter01/01_version_control_necessity.svg
+++ b/docs/assets/images/diagrams/chapter01/01_version_control_necessity.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -40,16 +40,16 @@
       
       <!-- ファイル例 -->
       <rect x="100" y="140" width="200" height="15" rx="2" class="bg-alt border"/>
-      <text x="110" y="152" class="text text-sm" style="font-family: monospace;">report.docx</text>
+      <text x="110" y="152" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">report.docx</text>
       
       <rect x="100" y="160" width="200" height="15" rx="2" class="bg-alt border"/>
-      <text x="110" y="172" class="text text-sm" style="font-family: monospace;">report_final.docx</text>
+      <text x="110" y="172" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">report_final.docx</text>
       
       <rect x="100" y="180" width="200" height="15" rx="2" class="bg-alt border"/>
-      <text x="110" y="192" class="text text-sm" style="font-family: monospace;">report_final_v2.docx</text>
+      <text x="110" y="192" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">report_final_v2.docx</text>
       
       <rect x="100" y="200" width="200" height="15" rx="2" class="bg-alt border"/>
-      <text x="110" y="212" class="text text-sm" style="font-family: monospace;">report_final_v2_本当の最終版.docx</text>
+      <text x="110" y="212" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">report_final_v2_本当の最終版.docx</text>
     </g>
     
     <!-- コラボレーション問題 -->

--- a/docs/assets/images/diagrams/chapter01/02_git_distributed_concept.svg
+++ b/docs/assets/images/diagrams/chapter01/02_git_distributed_concept.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter01/02_github_ecosystem.svg
+++ b/docs/assets/images/diagrams/chapter01/02_github_ecosystem.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter01/03_github_role_ecosystem.svg
+++ b/docs/assets/images/diagrams/chapter01/03_github_role_ecosystem.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter01/04_repository_concept.svg
+++ b/docs/assets/images/diagrams/chapter01/04_repository_concept.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -47,16 +47,16 @@
       
       <!-- ファイル例 -->
       <rect x="90" y="230" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="100" y="242" class="text text-sm" style="font-family: monospace;">README.md</text>
+      <text x="100" y="242" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">README.md</text>
       
       <rect x="90" y="250" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="100" y="262" class="text text-sm" style="font-family: monospace;">src/main.js</text>
+      <text x="100" y="262" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">src/main.js</text>
       
       <rect x="90" y="270" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="100" y="282" class="text text-sm" style="font-family: monospace;">package.json</text>
+      <text x="100" y="282" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">package.json</text>
       
       <rect x="90" y="290" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="100" y="302" class="text text-sm" style="font-family: monospace;">docs/</text>
+      <text x="100" y="302" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">docs/</text>
     </g>
     
     <!-- 履歴エリア -->

--- a/docs/assets/images/diagrams/chapter01/05_collaboration_flow.svg
+++ b/docs/assets/images/diagrams/chapter01/05_collaboration_flow.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter01/06_github_vs_alternatives.svg
+++ b/docs/assets/images/diagrams/chapter01/06_github_vs_alternatives.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter01/07_learning_roadmap.svg
+++ b/docs/assets/images/diagrams/chapter01/07_learning_roadmap.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter01/08_development_workflow_overview.svg
+++ b/docs/assets/images/diagrams/chapter01/08_development_workflow_overview.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter04/01_git_basic_operations.svg
+++ b/docs/assets/images/diagrams/chapter04/01_git_basic_operations.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -134,8 +134,8 @@
   <!-- コマンド例 -->
   <g class="command-examples">
     <rect x="100" y="380" width="600" height="25" rx="2" class="bg-alt border"/>
-    <text x="110" y="395" class="text text-sm" style="font-family: monospace;">git clone https://github.com/user/repo.git</text>
-    <text x="450" y="395" class="text text-sm" style="font-family: monospace;">git push origin main</text>
-    <text x="650" y="395" class="text text-sm" style="font-family: monospace;">git pull origin main</text>
+    <text x="110" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git clone https://github.com/user/repo.git</text>
+    <text x="450" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git push origin main</text>
+    <text x="650" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git pull origin main</text>
   </g>
 </svg>

--- a/docs/assets/images/diagrams/chapter04/01_web_ui_operation_flow.svg
+++ b/docs/assets/images/diagrams/chapter04/01_web_ui_operation_flow.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -143,11 +143,11 @@
       <text x="200" y="425" text-anchor="middle" class="text text-sm" style="font-weight: 600;">💬 コミットメッセージ</text>
       
       <rect x="110" y="440" width="180" height="20" rx="2" class="bg-alt border"/>
-      <text x="115" y="454" class="text text-sm" style="font-family: monospace;">Add user authentication</text>
+      <text x="115" y="454" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Add user authentication</text>
       
       <text x="110" y="475" class="text text-sm" style="font-weight: 600;">詳細説明（任意）:</text>
       <rect x="110" y="480" width="180" height="15" rx="2" class="bg-alt border"/>
-      <text x="115" y="492" class="text text-sm" style="font-family: monospace;">Login functionality...</text>
+      <text x="115" y="492" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Login functionality...</text>
     </g>
     
     <!-- ブランチ選択 -->

--- a/docs/assets/images/diagrams/chapter04/02_file_creation_editing_screen.svg
+++ b/docs/assets/images/diagrams/chapter04/02_file_creation_editing_screen.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -32,7 +32,7 @@
     
     <!-- アドレスバー -->
     <rect x="70" y="70" width="300" height="10" rx="2" class="bg-alt border"/>
-    <text x="75" y="78" class="text text-sm" style="font-family: monospace; font-size: 8px;">github.com/user/repo/new/main</text>
+    <text x="75" y="78" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-size: 8px;">github.com/user/repo/new/main</text>
     
     <!-- ナビゲーション -->
     <g class="navigation">
@@ -44,7 +44,7 @@
     <g class="filename-input">
       <text x="70" y="145" class="text text-sm" style="font-weight: 600;">Name your file...</text>
       <rect x="70" y="150" width="660" height="25" rx="2" class="primary border"/>
-      <text x="80" y="167" class="text text-sm" style="font-family: monospace;">components/Button.jsx</text>
+      <text x="80" y="167" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">components/Button.jsx</text>
       
       <!-- ファイルタイプ検出 -->
       <rect x="600" y="152" width="50" height="21" rx="10" class="success" opacity="0.2"/>
@@ -72,14 +72,14 @@
       <text x="75" y="330" class="text text-sm neutral">8</text>
       
       <!-- コード内容 -->
-      <text x="110" y="225" class="text text-sm" style="font-family: monospace;">import React from 'react';</text>
-      <text x="110" y="240" class="text text-sm" style="font-family: monospace;"></text>
-      <text x="110" y="255" class="text text-sm" style="font-family: monospace;">const Button = ({ children, onClick }) => {</text>
-      <text x="110" y="270" class="text text-sm" style="font-family: monospace;">  return (</text>
-      <text x="110" y="285" class="text text-sm" style="font-family: monospace;">    &lt;button onClick={onClick}&gt;</text>
-      <text x="110" y="300" class="text text-sm" style="font-family: monospace;">      {children}</text>
-      <text x="110" y="315" class="text text-sm" style="font-family: monospace;">    &lt;/button&gt;</text>
-      <text x="110" y="330" class="text text-sm" style="font-family: monospace;">  );</text>
+      <text x="110" y="225" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">import React from 'react';</text>
+      <text x="110" y="240" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"></text>
+      <text x="110" y="255" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">const Button = ({ children, onClick }) => {</text>
+      <text x="110" y="270" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">  return (</text>
+      <text x="110" y="285" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">    &lt;button onClick={onClick}&gt;</text>
+      <text x="110" y="300" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">      {children}</text>
+      <text x="110" y="315" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">    &lt;/button&gt;</text>
+      <text x="110" y="330" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">  );</text>
       
       <!-- カーソル -->
       <rect x="140" y="333" width="1" height="12" class="primary"/>
@@ -91,12 +91,12 @@
       
       <!-- コミットメッセージ -->
       <rect x="70" y="460" width="400" height="20" rx="2" class="border"/>
-      <text x="80" y="473" class="text text-sm" style="font-family: monospace;">Add Button component</text>
+      <text x="80" y="473" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Add Button component</text>
       
       <!-- 詳細説明 -->
       <rect x="70" y="485" width="400" height="40" rx="2" class="border"/>
-      <text x="80" y="498" class="text text-sm" style="font-family: monospace;">Create reusable button component</text>
-      <text x="80" y="513" class="text text-sm" style="font-family: monospace;">with click handler support</text>
+      <text x="80" y="498" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Create reusable button component</text>
+      <text x="80" y="513" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">with click handler support</text>
       
       <!-- ブランチオプション -->
       <g class="branch-options">
@@ -107,7 +107,7 @@
         <text x="515" y="495" class="text text-sm">Create a new branch for this commit and start a pull request</text>
         
         <rect x="515" y="500" width="150" height="15" rx="2" class="bg-alt border"/>
-        <text x="520" y="510" class="text text-sm" style="font-family: monospace;">feature/add-button</text>
+        <text x="520" y="510" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">feature/add-button</text>
       </g>
     </g>
     

--- a/docs/assets/images/diagrams/chapter04/02_repository_structure.svg
+++ b/docs/assets/images/diagrams/chapter04/02_repository_structure.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -96,22 +96,22 @@
       <rect x="80" y="330" width="640" height="100" rx="4" class="bg-alt border"/>
       <text x="90" y="350" class="text text-sm" style="font-weight: 600;">.gitignoreファイルの例</text>
       
-      <text x="100" y="370" class="text text-sm" style="font-family: monospace;"># 依存関係</text>
-      <text x="100" y="385" class="text text-sm" style="font-family: monospace;">node_modules/</text>
-      <text x="250" y="370" class="text text-sm" style="font-family: monospace;"># ビルド成果物</text>
-      <text x="250" y="385" class="text text-sm" style="font-family: monospace;">dist/</text>
-      <text x="350" y="370" class="text text-sm" style="font-family: monospace;"># 環境設定</text>
-      <text x="350" y="385" class="text text-sm" style="font-family: monospace;">.env</text>
-      <text x="450" y="370" class="text text-sm" style="font-family: monospace;"># OS固有</text>
-      <text x="450" y="385" class="text text-sm" style="font-family: monospace;">.DS_Store</text>
-      <text x="550" y="370" class="text text-sm" style="font-family: monospace;"># IDE設定</text>
-      <text x="550" y="385" class="text text-sm" style="font-family: monospace;">.vscode/</text>
+      <text x="100" y="370" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># 依存関係</text>
+      <text x="100" y="385" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">node_modules/</text>
+      <text x="250" y="370" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># ビルド成果物</text>
+      <text x="250" y="385" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">dist/</text>
+      <text x="350" y="370" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># 環境設定</text>
+      <text x="350" y="385" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">.env</text>
+      <text x="450" y="370" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># OS固有</text>
+      <text x="450" y="385" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">.DS_Store</text>
+      <text x="550" y="370" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># IDE設定</text>
+      <text x="550" y="385" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">.vscode/</text>
       
-      <text x="100" y="405" class="text text-sm" style="font-family: monospace;">*.log</text>
-      <text x="250" y="405" class="text text-sm" style="font-family: monospace;">build/</text>
-      <text x="350" y="405" class="text text-sm" style="font-family: monospace;">*.env.local</text>
-      <text x="450" y="405" class="text text-sm" style="font-family: monospace;">Thumbs.db</text>
-      <text x="550" y="405" class="text text-sm" style="font-family: monospace;">*.swp</text>
+      <text x="100" y="405" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.log</text>
+      <text x="250" y="405" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">build/</text>
+      <text x="350" y="405" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.env.local</text>
+      <text x="450" y="405" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Thumbs.db</text>
+      <text x="550" y="405" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.swp</text>
     </g>
     
     <!-- READMEファイルの重要性 -->

--- a/docs/assets/images/diagrams/chapter04/03_commit_creation_process.svg
+++ b/docs/assets/images/diagrams/chapter04/03_commit_creation_process.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -84,13 +84,13 @@
       
       <!-- サマリー -->
       <rect x="90" y="245" width="280" height="20" rx="2" class="bg-alt border"/>
-      <text x="95" y="258" class="text text-sm" style="font-family: monospace; font-weight: 600;">feat: Add user authentication system</text>
+      <text x="95" y="258" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-weight: 600;">feat: Add user authentication system</text>
       
       <!-- 詳細 -->
       <rect x="90" y="270" width="280" height="50" rx="2" class="bg-alt border"/>
-      <text x="95" y="283" class="text text-sm" style="font-family: monospace;">- Implement login/logout functionality</text>
-      <text x="95" y="296" class="text text-sm" style="font-family: monospace;">- Add password validation</text>
-      <text x="95" y="309" class="text text-sm" style="font-family: monospace;">- Include session management</text>
+      <text x="95" y="283" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Implement login/logout functionality</text>
+      <text x="95" y="296" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Add password validation</text>
+      <text x="95" y="309" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Include session management</text>
     </g>
     
     <!-- 悪い例 -->
@@ -100,16 +100,16 @@
       
       <!-- 悪いメッセージ例 -->
       <rect x="430" y="245" width="280" height="15" rx="2" class="bg-alt border"/>
-      <text x="435" y="255" class="text text-sm" style="font-family: monospace;">fix</text>
+      <text x="435" y="255" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">fix</text>
       
       <rect x="430" y="265" width="280" height="15" rx="2" class="bg-alt border"/>
-      <text x="435" y="275" class="text text-sm" style="font-family: monospace;">update</text>
+      <text x="435" y="275" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">update</text>
       
       <rect x="430" y="285" width="280" height="15" rx="2" class="bg-alt border"/>
-      <text x="435" y="295" class="text text-sm" style="font-family: monospace;">WIP</text>
+      <text x="435" y="295" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">WIP</text>
       
       <rect x="430" y="305" width="280" height="15" rx="2" class="bg-alt border"/>
-      <text x="435" y="315" class="text text-sm" style="font-family: monospace;">asdlfkjsldfkj</text>
+      <text x="435" y="315" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">asdlfkjsldfkj</text>
     </g>
   </g>
   

--- a/docs/assets/images/diagrams/chapter04/04_file_history_display.svg
+++ b/docs/assets/images/diagrams/chapter04/04_file_history_display.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -159,13 +159,13 @@
     
     <!-- 削除行 -->
     <rect x="90" y="530" width="620" height="12" rx="0" class="error" opacity="0.2"/>
-    <text x="95" y="540" class="text text-sm" style="font-family: monospace;">- const Button = () => {</text>
+    <text x="95" y="540" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- const Button = () => {</text>
     
     <!-- 追加行 -->
     <rect x="90" y="545" width="620" height="12" rx="0" class="success" opacity="0.2"/>
-    <text x="95" y="555" class="text text-sm" style="font-family: monospace;">+ const Button = ({ children, onClick }) => {</text>
+    <text x="95" y="555" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">+ const Button = ({ children, onClick }) => {</text>
     
     <!-- 変更なし -->
-    <text x="95" y="570" class="text text-sm" style="font-family: monospace;">    return &lt;button&gt;{children}&lt;/button&gt;;</text>
+    <text x="95" y="570" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">    return &lt;button&gt;{children}&lt;/button&gt;;</text>
   </g>
 </svg>

--- a/docs/assets/images/diagrams/chapter04/05_branch_file_operations.svg
+++ b/docs/assets/images/diagrams/chapter04/05_branch_file_operations.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter04/06_merge_concept.svg
+++ b/docs/assets/images/diagrams/chapter04/06_merge_concept.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter04/07_conflict_resolution.svg
+++ b/docs/assets/images/diagrams/chapter04/07_conflict_resolution.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -40,18 +40,18 @@
       <text x="205" y="115" text-anchor="middle" class="text text-sm" style="font-weight: 600;">main ブランチの変更</text>
       
       <rect x="90" y="125" width="230" height="40" rx="2" class="bg-alt border"/>
-      <text x="95" y="138" class="text text-sm" style="font-family: monospace;">function greet(name) {</text>
-      <text x="95" y="152" class="text text-sm" style="font-family: monospace; color: #28a745;">  return `Hello, ${name}!`;</text>
-      <text x="95" y="166" class="text text-sm" style="font-family: monospace;">}</text>
+      <text x="95" y="138" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">function greet(name) {</text>
+      <text x="95" y="152" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; color: #28a745;">  return `Hello, ${name}!`;</text>
+      <text x="95" y="166" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">}</text>
       
       <!-- featureブランチの変更 -->
       <rect x="470" y="95" width="250" height="80" rx="8" class="primary border" opacity="0.1"/>
       <text x="595" y="115" text-anchor="middle" class="text text-sm" style="font-weight: 600;">feature ブランチの変更</text>
       
       <rect x="480" y="125" width="230" height="40" rx="2" class="bg-alt border"/>
-      <text x="485" y="138" class="text text-sm" style="font-family: monospace;">function greet(name) {</text>
-      <text x="485" y="152" class="text text-sm" style="font-family: monospace; color: #007bff;">  return `Hi there, ${name}!`;</text>
-      <text x="485" y="166" class="text text-sm" style="font-family: monospace;">}</text>
+      <text x="485" y="138" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">function greet(name) {</text>
+      <text x="485" y="152" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; color: #007bff;">  return `Hi there, ${name}!`;</text>
+      <text x="485" y="166" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">}</text>
       
       <!-- 競合マーク -->
       <text x="400" y="145" text-anchor="middle" class="text text-md error" style="font-weight: 600;">⚡ 同じ行を異なる内容に変更</text>
@@ -67,12 +67,12 @@
     
     <!-- コンフリクト内容 -->
     <rect x="170" y="265" width="460" height="75" rx="2" class="bg-alt border"/>
-    <text x="175" y="278" class="text text-sm" style="font-family: monospace;">function greet(name) {</text>
-    <text x="175" y="292" class="text text-sm" style="font-family: monospace; color: #dc3545;">&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</text>
-    <text x="175" y="306" class="text text-sm" style="font-family: monospace; color: #28a745;">  return `Hello, ${name}!`;</text>
-    <text x="175" y="320" class="text text-sm" style="font-family: monospace; color: #6c757d;">=======</text>
-    <text x="175" y="334" class="text text-sm" style="font-family: monospace; color: #007bff;">  return `Hi there, ${name}!`;</text>
-    <text x="175" y="348" class="text text-sm" style="font-family: monospace; color: #dc3545;">&gt;&gt;&gt;&gt;&gt;&gt;&gt; feature/greeting</text>
+    <text x="175" y="278" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">function greet(name) {</text>
+    <text x="175" y="292" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; color: #dc3545;">&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</text>
+    <text x="175" y="306" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; color: #28a745;">  return `Hello, ${name}!`;</text>
+    <text x="175" y="320" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; color: #6c757d;">=======</text>
+    <text x="175" y="334" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; color: #007bff;">  return `Hi there, ${name}!`;</text>
+    <text x="175" y="348" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; color: #dc3545;">&gt;&gt;&gt;&gt;&gt;&gt;&gt; feature/greeting</text>
   </g>
   
   <!-- 解決プロセス -->
@@ -129,7 +129,7 @@
     <text x="400" y="545" text-anchor="middle" class="text text-sm" style="font-weight: 600;">resolved-file.js</text>
     
     <rect x="270" y="555" width="260" height="15" rx="2" class="bg-alt border"/>
-    <text x="275" y="565" class="text text-sm" style="font-family: monospace;">  return `Hello there, ${name}!`;</text>
+    <text x="275" y="565" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">  return `Hello there, ${name}!`;</text>
   </g>
   
   <!-- 解決のコツ -->

--- a/docs/assets/images/diagrams/chapter04/08_readme_importance.svg
+++ b/docs/assets/images/diagrams/chapter04/08_readme_importance.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -100,13 +100,13 @@
     <rect x="100" y="420" width="600" height="120" rx="8" class="bg-alt border"/>
     
     <!-- Markdown例 -->
-    <text x="120" y="440" class="text text-sm" style="font-family: monospace; font-weight: 600;"># Awesome Todo App</text>
-    <text x="120" y="455" class="text text-sm" style="font-family: monospace;">シンプルで使いやすいTodoアプリケーションです。</text>
-    <text x="120" y="475" class="text text-sm" style="font-family: monospace; font-weight: 600;">## インストール</text>
-    <text x="120" y="490" class="text text-sm" style="font-family: monospace;">```bash</text>
-    <text x="120" y="505" class="text text-sm" style="font-family: monospace;">npm install</text>
-    <text x="120" y="520" class="text text-sm" style="font-family: monospace;">npm start</text>
-    <text x="120" y="535" class="text text-sm" style="font-family: monospace;">```</text>
+    <text x="120" y="440" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-weight: 600;"># Awesome Todo App</text>
+    <text x="120" y="455" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">シンプルで使いやすいTodoアプリケーションです。</text>
+    <text x="120" y="475" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-weight: 600;">## インストール</text>
+    <text x="120" y="490" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">```bash</text>
+    <text x="120" y="505" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">npm install</text>
+    <text x="120" y="520" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">npm start</text>
+    <text x="120" y="535" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">```</text>
   </g>
   
   <!-- READMEの効果 -->

--- a/docs/assets/images/diagrams/chapter04/09_license_selection.svg
+++ b/docs/assets/images/diagrams/chapter04/09_license_selection.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter04/10_gitignore_patterns.svg
+++ b/docs/assets/images/diagrams/chapter04/10_gitignore_patterns.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -43,10 +43,10 @@
       <text x="150" y="225" text-anchor="middle" class="text text-sm" style="font-weight: 600;">📄 具体的ファイル</text>
       
       <rect x="90" y="235" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="95" y="247" class="text text-sm" style="font-family: monospace;">config.json</text>
+      <text x="95" y="247" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">config.json</text>
       
       <rect x="90" y="255" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="95" y="267" class="text text-sm" style="font-family: monospace;">secret.key</text>
+      <text x="95" y="267" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">secret.key</text>
     </g>
     
     <!-- ワイルドカード -->
@@ -55,10 +55,10 @@
       <text x="310" y="225" text-anchor="middle" class="text text-sm" style="font-weight: 600;">🌟 ワイルドカード</text>
       
       <rect x="250" y="235" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="255" y="247" class="text text-sm" style="font-family: monospace;">*.log</text>
+      <text x="255" y="247" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.log</text>
       
       <rect x="250" y="255" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="255" y="267" class="text text-sm" style="font-family: monospace;">temp_*</text>
+      <text x="255" y="267" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">temp_*</text>
     </g>
     
     <!-- ディレクトリ -->
@@ -67,10 +67,10 @@
       <text x="470" y="225" text-anchor="middle" class="text text-sm" style="font-weight: 600;">📁 ディレクトリ</text>
       
       <rect x="410" y="235" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="415" y="247" class="text text-sm" style="font-family: monospace;">node_modules/</text>
+      <text x="415" y="247" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">node_modules/</text>
       
       <rect x="410" y="255" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="415" y="267" class="text text-sm" style="font-family: monospace;">build/</text>
+      <text x="415" y="267" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">build/</text>
     </g>
     
     <!-- 再帰パターン -->
@@ -79,10 +79,10 @@
       <text x="630" y="225" text-anchor="middle" class="text text-sm" style="font-weight: 600;">🔄 再帰パターン</text>
       
       <rect x="570" y="235" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="575" y="247" class="text text-sm" style="font-family: monospace;">**/debug.log</text>
+      <text x="575" y="247" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">**/debug.log</text>
       
       <rect x="570" y="255" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="575" y="267" class="text text-sm" style="font-family: monospace;">src/**/*.tmp</text>
+      <text x="575" y="267" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">src/**/*.tmp</text>
     </g>
   </g>
   
@@ -95,10 +95,10 @@
       <rect x="80" y="340" width="150" height="100" rx="8" class="success border" opacity="0.1"/>
       <text x="155" y="365" text-anchor="middle" class="text text-sm" style="font-weight: 600;">📗 Node.js</text>
       
-      <text x="90" y="380" class="text text-sm" style="font-family: monospace;">node_modules/</text>
-      <text x="90" y="395" class="text text-sm" style="font-family: monospace;">npm-debug.log*</text>
-      <text x="90" y="410" class="text text-sm" style="font-family: monospace;">.env</text>
-      <text x="90" y="425" class="text text-sm" style="font-family: monospace;">dist/</text>
+      <text x="90" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">node_modules/</text>
+      <text x="90" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">npm-debug.log*</text>
+      <text x="90" y="410" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">.env</text>
+      <text x="90" y="425" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">dist/</text>
     </g>
     
     <!-- Python -->
@@ -106,10 +106,10 @@
       <rect x="250" y="340" width="150" height="100" rx="8" class="primary border" opacity="0.1"/>
       <text x="325" y="365" text-anchor="middle" class="text text-sm" style="font-weight: 600;">🐍 Python</text>
       
-      <text x="260" y="380" class="text text-sm" style="font-family: monospace;">__pycache__/</text>
-      <text x="260" y="395" class="text text-sm" style="font-family: monospace;">*.pyc</text>
-      <text x="260" y="410" class="text text-sm" style="font-family: monospace;">.pytest_cache/</text>
-      <text x="260" y="425" class="text text-sm" style="font-family: monospace;">venv/</text>
+      <text x="260" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">__pycache__/</text>
+      <text x="260" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.pyc</text>
+      <text x="260" y="410" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">.pytest_cache/</text>
+      <text x="260" y="425" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">venv/</text>
     </g>
     
     <!-- Java -->
@@ -117,10 +117,10 @@
       <rect x="420" y="340" width="150" height="100" rx="8" class="warning border" opacity="0.1"/>
       <text x="495" y="365" text-anchor="middle" class="text text-sm" style="font-weight: 600;">☕ Java</text>
       
-      <text x="430" y="380" class="text text-sm" style="font-family: monospace;">*.class</text>
-      <text x="430" y="395" class="text text-sm" style="font-family: monospace;">target/</text>
-      <text x="430" y="410" class="text text-sm" style="font-family: monospace;">*.jar</text>
-      <text x="430" y="425" class="text text-sm" style="font-family: monospace;">.gradle/</text>
+      <text x="430" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.class</text>
+      <text x="430" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">target/</text>
+      <text x="430" y="410" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.jar</text>
+      <text x="430" y="425" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">.gradle/</text>
     </g>
     
     <!-- 共通パターン -->
@@ -128,10 +128,10 @@
       <rect x="590" y="340" width="150" height="100" rx="8" class="neutral border" opacity="0.1"/>
       <text x="665" y="365" text-anchor="middle" class="text text-sm" style="font-weight: 600;">🌐 共通</text>
       
-      <text x="600" y="380" class="text text-sm" style="font-family: monospace;">.DS_Store</text>
-      <text x="600" y="395" class="text text-sm" style="font-family: monospace;">Thumbs.db</text>
-      <text x="600" y="410" class="text text-sm" style="font-family: monospace;">*.log</text>
-      <text x="600" y="425" class="text text-sm" style="font-family: monospace;">*.tmp</text>
+      <text x="600" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">.DS_Store</text>
+      <text x="600" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Thumbs.db</text>
+      <text x="600" y="410" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.log</text>
+      <text x="600" y="425" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.tmp</text>
     </g>
   </g>
   
@@ -143,16 +143,16 @@
     <g class="negation">
       <rect x="120" y="490" width="160" height="60" rx="4" class="error border" opacity="0.1"/>
       <text x="200" y="510" text-anchor="middle" class="text text-sm" style="font-weight: 600;">❗ 否定パターン</text>
-      <text x="130" y="525" class="text text-sm" style="font-family: monospace;">*.log</text>
-      <text x="130" y="540" class="text text-sm" style="font-family: monospace;">!important.log</text>
+      <text x="130" y="525" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.log</text>
+      <text x="130" y="540" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">!important.log</text>
     </g>
     
     <!-- コメント -->
     <g class="comments">
       <rect x="300" y="490" width="160" height="60" rx="4" class="primary border" opacity="0.1"/>
       <text x="380" y="510" text-anchor="middle" class="text text-sm" style="font-weight: 600;">💬 コメント</text>
-      <text x="310" y="525" class="text text-sm" style="font-family: monospace;"># ログファイル</text>
-      <text x="310" y="540" class="text text-sm" style="font-family: monospace;">*.log</text>
+      <text x="310" y="525" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># ログファイル</text>
+      <text x="310" y="540" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.log</text>
     </g>
     
     <!-- 空行の意味 -->

--- a/docs/assets/images/diagrams/chapter04/11_file_permissions_management.svg
+++ b/docs/assets/images/diagrams/chapter04/11_file_permissions_management.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -114,10 +114,10 @@
     <text x="400" y="450" text-anchor="middle" class="text text-sm" style="font-weight: 600;">.github/CODEOWNERS</text>
     
     <!-- CODEOWNERSの内容 -->
-    <text x="160" y="470" class="text text-sm" style="font-family: monospace;"># グローバルオーナー</text>
-    <text x="160" y="485" class="text text-sm" style="font-family: monospace;">* @team-lead @senior-dev</text>
-    <text x="160" y="500" class="text text-sm" style="font-family: monospace;"># フロントエンド</text>
-    <text x="160" y="515" class="text text-sm" style="font-family: monospace;">src/frontend/ @frontend-team</text>
+    <text x="160" y="470" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># グローバルオーナー</text>
+    <text x="160" y="485" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">* @team-lead @senior-dev</text>
+    <text x="160" y="500" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;"># フロントエンド</text>
+    <text x="160" y="515" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">src/frontend/ @frontend-team</text>
   </g>
   
   <!-- 権限管理のベストプラクティス -->

--- a/docs/assets/images/diagrams/chapter04/12_large_file_handling.svg
+++ b/docs/assets/images/diagrams/chapter04/12_large_file_handling.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -146,8 +146,8 @@
     <text x="400" y="520" text-anchor="middle" class="text text-sm" style="font-weight: 600;">.gitattributes</text>
     
     <!-- 設定内容 -->
-    <text x="160" y="540" class="text text-sm" style="font-family: monospace;">*.psd filter=lfs diff=lfs merge=lfs -text</text>
-    <text x="160" y="555" class="text text-sm" style="font-family: monospace;">*.mp4 filter=lfs diff=lfs merge=lfs -text</text>
+    <text x="160" y="540" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.psd filter=lfs diff=lfs merge=lfs -text</text>
+    <text x="160" y="555" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">*.mp4 filter=lfs diff=lfs merge=lfs -text</text>
   </g>
   
   <!-- 代替案 -->

--- a/docs/assets/images/diagrams/chapter04/13_binary_file_management.svg
+++ b/docs/assets/images/diagrams/chapter04/13_binary_file_management.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter04/14_directory_structure_design.svg
+++ b/docs/assets/images/diagrams/chapter04/14_directory_structure_design.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -74,14 +74,14 @@
       <rect x="80" y="230" width="200" height="160" rx="8" class="primary border" opacity="0.1"/>
       <text x="180" y="255" text-anchor="middle" class="text text-sm" style="font-weight: 600;">🌐 Webアプリケーション</text>
       
-      <text x="90" y="275" class="text text-sm" style="font-family: monospace;">📁 project-root/</text>
-      <text x="100" y="290" class="text text-sm" style="font-family: monospace;">├── 📁 src/</text>
-      <text x="110" y="305" class="text text-sm" style="font-family: monospace;">│   ├── 📁 components/</text>
-      <text x="110" y="320" class="text text-sm" style="font-family: monospace;">│   ├── 📁 pages/</text>
-      <text x="110" y="335" class="text text-sm" style="font-family: monospace;">│   └── 📁 utils/</text>
-      <text x="100" y="350" class="text text-sm" style="font-family: monospace;">├── 📁 public/</text>
-      <text x="100" y="365" class="text text-sm" style="font-family: monospace;">├── 📁 tests/</text>
-      <text x="100" y="380" class="text text-sm" style="font-family: monospace;">└── 📄 package.json</text>
+      <text x="90" y="275" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">📁 project-root/</text>
+      <text x="100" y="290" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 src/</text>
+      <text x="110" y="305" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">│   ├── 📁 components/</text>
+      <text x="110" y="320" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">│   ├── 📁 pages/</text>
+      <text x="110" y="335" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">│   └── 📁 utils/</text>
+      <text x="100" y="350" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 public/</text>
+      <text x="100" y="365" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 tests/</text>
+      <text x="100" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">└── 📄 package.json</text>
     </g>
     
     <!-- ライブラリ -->
@@ -89,14 +89,14 @@
       <rect x="300" y="230" width="200" height="160" rx="8" class="success border" opacity="0.1"/>
       <text x="400" y="255" text-anchor="middle" class="text text-sm" style="font-weight: 600;">📚 ライブラリ</text>
       
-      <text x="310" y="275" class="text text-sm" style="font-family: monospace;">📁 library-name/</text>
-      <text x="320" y="290" class="text text-sm" style="font-family: monospace;">├── 📁 lib/</text>
-      <text x="330" y="305" class="text text-sm" style="font-family: monospace;">│   ├── 📄 index.js</text>
-      <text x="330" y="320" class="text text-sm" style="font-family: monospace;">│   └── 📁 modules/</text>
-      <text x="320" y="335" class="text text-sm" style="font-family: monospace;">├── 📁 docs/</text>
-      <text x="320" y="350" class="text text-sm" style="font-family: monospace;">├── 📁 examples/</text>
-      <text x="320" y="365" class="text text-sm" style="font-family: monospace;">├── 📁 test/</text>
-      <text x="320" y="380" class="text text-sm" style="font-family: monospace;">└── 📄 README.md</text>
+      <text x="310" y="275" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">📁 library-name/</text>
+      <text x="320" y="290" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 lib/</text>
+      <text x="330" y="305" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">│   ├── 📄 index.js</text>
+      <text x="330" y="320" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">│   └── 📁 modules/</text>
+      <text x="320" y="335" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 docs/</text>
+      <text x="320" y="350" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 examples/</text>
+      <text x="320" y="365" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 test/</text>
+      <text x="320" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">└── 📄 README.md</text>
     </g>
     
     <!-- データサイエンス -->
@@ -104,14 +104,14 @@
       <rect x="520" y="230" width="200" height="160" rx="8" class="warning border" opacity="0.1"/>
       <text x="620" y="255" text-anchor="middle" class="text text-sm" style="font-weight: 600;">📊 データサイエンス</text>
       
-      <text x="530" y="275" class="text text-sm" style="font-family: monospace;">📁 data-project/</text>
-      <text x="540" y="290" class="text text-sm" style="font-family: monospace;">├── 📁 data/</text>
-      <text x="550" y="305" class="text text-sm" style="font-family: monospace;">│   ├── 📁 raw/</text>
-      <text x="550" y="320" class="text text-sm" style="font-family: monospace;">│   └── 📁 processed/</text>
-      <text x="540" y="335" class="text text-sm" style="font-family: monospace;">├── 📁 notebooks/</text>
-      <text x="540" y="350" class="text text-sm" style="font-family: monospace;">├── 📁 scripts/</text>
-      <text x="540" y="365" class="text text-sm" style="font-family: monospace;">├── 📁 models/</text>
-      <text x="540" y="380" class="text text-sm" style="font-family: monospace;">└── 📄 requirements.txt</text>
+      <text x="530" y="275" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">📁 data-project/</text>
+      <text x="540" y="290" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 data/</text>
+      <text x="550" y="305" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">│   ├── 📁 raw/</text>
+      <text x="550" y="320" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">│   └── 📁 processed/</text>
+      <text x="540" y="335" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 notebooks/</text>
+      <text x="540" y="350" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 scripts/</text>
+      <text x="540" y="365" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">├── 📁 models/</text>
+      <text x="540" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">└── 📄 requirements.txt</text>
     </g>
   </g>
   

--- a/docs/assets/images/diagrams/chapter04/15_naming_conventions_best_practices.svg
+++ b/docs/assets/images/diagrams/chapter04/15_naming_conventions_best_practices.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -44,14 +44,14 @@
       
       <!-- ファイル名 -->
       <text x="90" y="245" class="text text-sm" style="font-weight: 600;">📄 ファイル名:</text>
-      <text x="90" y="260" class="text text-sm" style="font-family: monospace;">user-profile.component.js</text>
-      <text x="90" y="275" class="text text-sm" style="font-family: monospace;">api-client.service.js</text>
-      <text x="90" y="290" class="text text-sm" style="font-family: monospace;">user-authentication.test.js</text>
+      <text x="90" y="260" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">user-profile.component.js</text>
+      <text x="90" y="275" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">api-client.service.js</text>
+      <text x="90" y="290" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">user-authentication.test.js</text>
       
       <!-- ディレクトリ名 -->
       <text x="90" y="310" class="text text-sm" style="font-weight: 600;">📁 ディレクトリ名:</text>
-      <text x="90" y="325" class="text text-sm" style="font-family: monospace;">components/user-interface/</text>
-      <text x="90" y="340" class="text text-sm" style="font-family: monospace;">utils/date-formatting/</text>
+      <text x="90" y="325" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">components/user-interface/</text>
+      <text x="90" y="340" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">utils/date-formatting/</text>
     </g>
     
     <!-- 悪い例 -->
@@ -61,14 +61,14 @@
       
       <!-- ファイル名 -->
       <text x="430" y="245" class="text text-sm" style="font-weight: 600;">📄 ファイル名:</text>
-      <text x="430" y="260" class="text text-sm" style="font-family: monospace;">UsrPrf.js (略語)</text>
-      <text x="430" y="275" class="text text-sm" style="font-family: monospace;">temp123.js (意味不明)</text>
-      <text x="430" y="290" class="text text-sm" style="font-family: monospace;">USERDATA (拡張子なし)</text>
+      <text x="430" y="260" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">UsrPrf.js (略語)</text>
+      <text x="430" y="275" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">temp123.js (意味不明)</text>
+      <text x="430" y="290" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">USERDATA (拡張子なし)</text>
       
       <!-- ディレクトリ名 -->
       <text x="430" y="310" class="text text-sm" style="font-weight: 600;">📁 ディレクトリ名:</text>
-      <text x="430" y="325" class="text text-sm" style="font-family: monospace;">stuff/ (曖昧)</text>
-      <text x="430" y="340" class="text text-sm" style="font-family: monospace;">NEW FOLDER/ (スペース)</text>
+      <text x="430" y="325" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">stuff/ (曖昧)</text>
+      <text x="430" y="340" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">NEW FOLDER/ (スペース)</text>
     </g>
   </g>
   
@@ -80,40 +80,40 @@
     <g class="javascript-conventions">
       <rect x="80" y="390" width="160" height="100" rx="8" class="primary border" opacity="0.1"/>
       <text x="160" y="415" text-anchor="middle" class="text text-sm" style="font-weight: 600;">📗 JavaScript/React</text>
-      <text x="90" y="435" class="text text-sm" style="font-family: monospace;">camelCase</text>
-      <text x="90" y="450" class="text text-sm" style="font-family: monospace;">UserProfile.jsx</text>
-      <text x="90" y="465" class="text text-sm" style="font-family: monospace;">apiClient.js</text>
-      <text x="90" y="480" class="text text-sm" style="font-family: monospace;">user.service.js</text>
+      <text x="90" y="435" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">camelCase</text>
+      <text x="90" y="450" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">UserProfile.jsx</text>
+      <text x="90" y="465" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">apiClient.js</text>
+      <text x="90" y="480" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">user.service.js</text>
     </g>
     
     <!-- Python -->
     <g class="python-conventions">
       <rect x="260" y="390" width="160" height="100" rx="8" class="success border" opacity="0.1"/>
       <text x="340" y="415" text-anchor="middle" class="text text-sm" style="font-weight: 600;">🐍 Python</text>
-      <text x="270" y="435" class="text text-sm" style="font-family: monospace;">snake_case</text>
-      <text x="270" y="450" class="text text-sm" style="font-family: monospace;">user_profile.py</text>
-      <text x="270" y="465" class="text text-sm" style="font-family: monospace;">api_client.py</text>
-      <text x="270" y="480" class="text text-sm" style="font-family: monospace;">test_user.py</text>
+      <text x="270" y="435" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">snake_case</text>
+      <text x="270" y="450" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">user_profile.py</text>
+      <text x="270" y="465" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">api_client.py</text>
+      <text x="270" y="480" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">test_user.py</text>
     </g>
     
     <!-- Java -->
     <g class="java-conventions">
       <rect x="440" y="390" width="160" height="100" rx="8" class="warning border" opacity="0.1"/>
       <text x="520" y="415" text-anchor="middle" class="text text-sm" style="font-weight: 600;">☕ Java</text>
-      <text x="450" y="435" class="text text-sm" style="font-family: monospace;">PascalCase</text>
-      <text x="450" y="450" class="text text-sm" style="font-family: monospace;">UserProfile.java</text>
-      <text x="450" y="465" class="text text-sm" style="font-family: monospace;">ApiClient.java</text>
-      <text x="450" y="480" class="text text-sm" style="font-family: monospace;">UserTest.java</text>
+      <text x="450" y="435" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">PascalCase</text>
+      <text x="450" y="450" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">UserProfile.java</text>
+      <text x="450" y="465" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">ApiClient.java</text>
+      <text x="450" y="480" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">UserTest.java</text>
     </g>
     
     <!-- CSS/SCSS -->
     <g class="css-conventions">
       <rect x="620" y="390" width="160" height="100" rx="8" class="neutral border" opacity="0.1"/>
       <text x="700" y="415" text-anchor="middle" class="text text-sm" style="font-weight: 600;">🎨 CSS/SCSS</text>
-      <text x="630" y="435" class="text text-sm" style="font-family: monospace;">kebab-case</text>
-      <text x="630" y="450" class="text text-sm" style="font-family: monospace;">user-profile.css</text>
-      <text x="630" y="465" class="text text-sm" style="font-family: monospace;">main-layout.scss</text>
-      <text x="630" y="480" class="text text-sm" style="font-family: monospace;">button-styles.css</text>
+      <text x="630" y="435" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">kebab-case</text>
+      <text x="630" y="450" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">user-profile.css</text>
+      <text x="630" y="465" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">main-layout.scss</text>
+      <text x="630" y="480" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">button-styles.css</text>
     </g>
   </g>
   

--- a/docs/assets/images/diagrams/chapter05/01_commit_best_practices.svg
+++ b/docs/assets/images/diagrams/chapter05/01_commit_best_practices.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -31,22 +31,22 @@
     
     <!-- コミット1 -->
     <rect x="70" y="110" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="80" y="125" class="text text-sm" style="font-family: monospace;">feat: Add user authentication system</text>
+    <text x="80" y="125" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">feat: Add user authentication system</text>
     <text x="80" y="135" class="text text-sm">• 機能追加を明確に表現</text>
     
     <!-- コミット2 -->
     <rect x="70" y="150" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="80" y="165" class="text text-sm" style="font-family: monospace;">fix: Resolve memory leak in image processing</text>
+    <text x="80" y="165" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">fix: Resolve memory leak in image processing</text>
     <text x="80" y="175" class="text text-sm">• 問題と解決内容が具体的</text>
     
     <!-- コミット3 -->
     <rect x="70" y="190" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="80" y="205" class="text text-sm" style="font-family: monospace;">docs: Update API documentation for v2.0</text>
+    <text x="80" y="205" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">docs: Update API documentation for v2.0</text>
     <text x="80" y="215" class="text text-sm">• 変更種別と対象が明確</text>
     
     <!-- コミット4 -->
     <rect x="70" y="230" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="80" y="245" class="text text-sm" style="font-family: monospace;">refactor: Extract validation logic to utils</text>
+    <text x="80" y="245" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">refactor: Extract validation logic to utils</text>
     <text x="80" y="255" class="text text-sm">• リファクタリング目的が明確</text>
   </g>
   
@@ -57,22 +57,22 @@
     
     <!-- コミット1 -->
     <rect x="450" y="110" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="460" y="125" class="text text-sm" style="font-family: monospace;">fix</text>
+    <text x="460" y="125" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">fix</text>
     <text x="460" y="135" class="text text-sm">• 何を修正したか不明</text>
     
     <!-- コミット2 -->
     <rect x="450" y="150" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="460" y="165" class="text text-sm" style="font-family: monospace;">Update multiple files for new feature</text>
+    <text x="460" y="165" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Update multiple files for new feature</text>
     <text x="460" y="175" class="text text-sm">• 変更内容が曖昧で広すぎる</text>
     
     <!-- コミット3 -->
     <rect x="450" y="190" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="460" y="205" class="text text-sm" style="font-family: monospace;">WIP: trying to fix bug</text>
+    <text x="460" y="205" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">WIP: trying to fix bug</text>
     <text x="460" y="215" class="text text-sm">• 作業中コミットは避ける</text>
     
     <!-- コミット4 -->
     <rect x="450" y="230" width="280" height="30" rx="4" class="bg-alt border"/>
-    <text x="460" y="245" class="text text-sm" style="font-family: monospace;">asdflkjweoriuqwer</text>
+    <text x="460" y="245" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">asdflkjweoriuqwer</text>
     <text x="460" y="255" class="text text-sm">• 意味のないメッセージ</text>
   </g>
   

--- a/docs/assets/images/diagrams/chapter05/01_github_desktop_overview.svg
+++ b/docs/assets/images/diagrams/chapter05/01_github_desktop_overview.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/02_installation_setup_process.svg
+++ b/docs/assets/images/diagrams/chapter05/02_installation_setup_process.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/03_interface_layout_elements.svg
+++ b/docs/assets/images/diagrams/chapter05/03_interface_layout_elements.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -99,11 +99,11 @@
       <text x="475" y="220" text-anchor="middle" class="text text-sm" style="font-weight: 600;">差分表示エリア</text>
       
       <!-- コード例 -->
-      <text x="280" y="250" class="text text-sm" style="font-family: monospace;">- const oldValue = 'old';</text>
-      <text x="280" y="270" class="text text-sm" style="font-family: monospace;">+ const newValue = 'new';</text>
-      <text x="280" y="290" class="text text-sm" style="font-family: monospace;">  function example() {</text>
-      <text x="280" y="310" class="text text-sm" style="font-family: monospace;">    return 'sample';</text>
-      <text x="280" y="330" class="text text-sm" style="font-family: monospace;">  }</text>
+      <text x="280" y="250" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- const oldValue = 'old';</text>
+      <text x="280" y="270" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">+ const newValue = 'new';</text>
+      <text x="280" y="290" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">  function example() {</text>
+      <text x="280" y="310" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">    return 'sample';</text>
+      <text x="280" y="330" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">  }</text>
       
       <!-- 統計情報 -->
       <rect x="270" y="420" width="410" height="60" rx="4" class="success border" opacity="0.1"/>

--- a/docs/assets/images/diagrams/chapter05/04_repository_cloning_creation.svg
+++ b/docs/assets/images/diagrams/chapter05/04_repository_cloning_creation.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -83,7 +83,7 @@
       
       <!-- URL入力フィールド -->
       <rect x="80" y="325" width="120" height="15" rx="2" class="border"/>
-      <text x="90" y="337" class="text text-sm" style="font-family: monospace; font-size: 10px;">github.com/user/repo</text>
+      <text x="90" y="337" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-size: 10px;">github.com/user/repo</text>
       
       <text x="140" y="355" text-anchor="middle" class="text text-sm">• HTTPS URL</text>
       <text x="140" y="370" text-anchor="middle" class="text text-sm">• SSH URL</text>
@@ -100,7 +100,7 @@
       
       <!-- パス表示 -->
       <rect x="260" y="325" width="120" height="15" rx="2" class="border"/>
-      <text x="270" y="337" class="text text-sm" style="font-family: monospace; font-size: 10px;">/Users/name/GitHub/</text>
+      <text x="270" y="337" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-size: 10px;">/Users/name/GitHub/</text>
       
       <text x="320" y="355" text-anchor="middle" class="text text-sm">• ローカルパス</text>
       <text x="320" y="370" text-anchor="middle" class="text text-sm">• フォルダ名</text>
@@ -152,17 +152,17 @@
       <!-- 名前 -->
       <text x="170" y="505" class="text text-sm" style="font-weight: 600;">Name:</text>
       <rect x="220" y="495" width="150" height="15" rx="2" class="border"/>
-      <text x="225" y="507" class="text text-sm" style="font-family: monospace;">my-new-project</text>
+      <text x="225" y="507" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">my-new-project</text>
       
       <!-- 説明 -->
       <text x="170" y="525" class="text text-sm" style="font-weight: 600;">Description:</text>
       <rect x="250" y="515" width="180" height="15" rx="2" class="border"/>
-      <text x="255" y="527" class="text text-sm" style="font-family: monospace;">Project description</text>
+      <text x="255" y="527" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Project description</text>
       
       <!-- パス -->
       <text x="170" y="545" class="text text-sm" style="font-weight: 600;">Local path:</text>
       <rect x="240" y="535" width="200" height="15" rx="2" class="border"/>
-      <text x="245" y="547" class="text text-sm" style="font-family: monospace;">/Users/name/Documents/</text>
+      <text x="245" y="547" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">/Users/name/Documents/</text>
       
       <!-- オプション -->
       <text x="470" y="505" class="text text-sm">☑️ Initialize with README</text>

--- a/docs/assets/images/diagrams/chapter05/05_file_changes_staging.svg
+++ b/docs/assets/images/diagrams/chapter05/05_file_changes_staging.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -130,13 +130,13 @@
       <text x="540" y="310" text-anchor="middle" class="text text-sm" style="font-weight: 600;">📊 Diff View</text>
       
       <!-- コード差分 -->
-      <text x="410" y="330" class="text text-sm" style="font-family: monospace;">1  &lt;html&gt;</text>
-      <text x="410" y="345" class="text text-sm" style="font-family: monospace;">2- &lt;title&gt;Old Title&lt;/title&gt;</text>
-      <text x="410" y="360" class="text text-sm" style="font-family: monospace;">3+ &lt;title&gt;New Title&lt;/title&gt;</text>
-      <text x="410" y="375" class="text text-sm" style="font-family: monospace;">4  &lt;body&gt;</text>
-      <text x="410" y="390" class="text text-sm" style="font-family: monospace;">5+   &lt;p&gt;Added content&lt;/p&gt;</text>
-      <text x="410" y="405" class="text text-sm" style="font-family: monospace;">6  &lt;/body&gt;</text>
-      <text x="410" y="420" class="text text-sm" style="font-family: monospace;">7  &lt;/html&gt;</text>
+      <text x="410" y="330" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">1  &lt;html&gt;</text>
+      <text x="410" y="345" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">2- &lt;title&gt;Old Title&lt;/title&gt;</text>
+      <text x="410" y="360" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">3+ &lt;title&gt;New Title&lt;/title&gt;</text>
+      <text x="410" y="375" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">4  &lt;body&gt;</text>
+      <text x="410" y="390" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">5+   &lt;p&gt;Added content&lt;/p&gt;</text>
+      <text x="410" y="405" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">6  &lt;/body&gt;</text>
+      <text x="410" y="420" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">7  &lt;/html&gt;</text>
     </g>
   </g>
   

--- a/docs/assets/images/diagrams/chapter05/06_commit_process_gui.svg
+++ b/docs/assets/images/diagrams/chapter05/06_commit_process_gui.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -89,7 +89,7 @@
     <g class="summary-field">
       <text x="170" y="280" class="text text-sm" style="font-weight: 600;">📝 Summary（必須）</text>
       <rect x="170" y="290" width="460" height="25" rx="4" class="border"/>
-      <text x="180" y="308" class="text text-sm" style="font-family: monospace;">feat: Add user authentication system</text>
+      <text x="180" y="308" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">feat: Add user authentication system</text>
       
       <!-- 文字数カウンター -->
       <text x="600" y="308" class="text text-sm" style="fill: #666;">50/50</text>
@@ -99,9 +99,9 @@
     <g class="description-field">
       <text x="170" y="335" class="text text-sm" style="font-weight: 600;">📄 Description（任意）</text>
       <rect x="170" y="345" width="460" height="60" rx="4" class="border"/>
-      <text x="180" y="365" class="text text-sm" style="font-family: monospace;">- Implement login/logout functionality</text>
-      <text x="180" y="380" class="text text-sm" style="font-family: monospace;">- Add password validation</text>
-      <text x="180" y="395" class="text text-sm" style="font-family: monospace;">- Update user interface</text>
+      <text x="180" y="365" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Implement login/logout functionality</text>
+      <text x="180" y="380" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Add password validation</text>
+      <text x="180" y="395" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Update user interface</text>
     </g>
     
     <!-- コミットボタン -->

--- a/docs/assets/images/diagrams/chapter05/07_branch_management_desktop.svg
+++ b/docs/assets/images/diagrams/chapter05/07_branch_management_desktop.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -74,7 +74,7 @@
       
       <!-- 入力フィールド -->
       <rect x="130" y="285" width="120" height="20" rx="2" class="border"/>
-      <text x="135" y="299" class="text text-sm" style="font-family: monospace;">feature/user-auth</text>
+      <text x="135" y="299" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">feature/user-auth</text>
       
       <text x="190" y="320" text-anchor="middle" class="text text-sm">意味のある名前</text>
     </g>

--- a/docs/assets/images/diagrams/chapter05/08_push_pull_sync_operations.svg
+++ b/docs/assets/images/diagrams/chapter05/08_push_pull_sync_operations.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/09_history_timeline_view.svg
+++ b/docs/assets/images/diagrams/chapter05/09_history_timeline_view.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -109,7 +109,7 @@
     <!-- 検索バー -->
     <g class="search-bar">
       <rect x="150" y="350" width="200" height="30" rx="4" class="border"/>
-      <text x="160" y="370" class="text text-sm" style="font-family: monospace;">🔍 Search commits...</text>
+      <text x="160" y="370" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">🔍 Search commits...</text>
       
       <text x="150" y="395" class="text text-sm" style="font-weight: 600;">検索対象:</text>
       <text x="150" y="410" class="text text-sm">• コミットメッセージ</text>

--- a/docs/assets/images/diagrams/chapter05/10_merge_conflict_resolution_gui.svg
+++ b/docs/assets/images/diagrams/chapter05/10_merge_conflict_resolution_gui.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -121,25 +121,25 @@
     
     <!-- 競合マーカー表示 -->
     <g class="conflict-markers">
-      <text x="160" y="440" class="text text-sm" style="font-family: monospace; font-weight: 600;">conflict-markers.js</text>
+      <text x="160" y="440" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-weight: 600;">conflict-markers.js</text>
       
       <!-- HEAD部分 -->
       <rect x="160" y="450" width="470" height="15" rx="2" class="success border" opacity="0.1"/>
-      <text x="165" y="462" class="text text-sm" style="font-family: monospace;">&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD (Current Change)</text>
+      <text x="165" y="462" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD (Current Change)</text>
       
       <rect x="160" y="467" width="470" height="15" rx="2" class="success border" opacity="0.1"/>
-      <text x="165" y="479" class="text text-sm" style="font-family: monospace;">const title = "Current Branch Title";</text>
+      <text x="165" y="479" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">const title = "Current Branch Title";</text>
       
       <!-- 区切り -->
       <rect x="160" y="484" width="470" height="15" rx="2" class="neutral border" opacity="0.1"/>
-      <text x="165" y="496" class="text text-sm" style="font-family: monospace;">======= (Separator)</text>
+      <text x="165" y="496" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">======= (Separator)</text>
       
       <!-- incoming部分 -->
       <rect x="160" y="501" width="470" height="15" rx="2" class="warning border" opacity="0.1"/>
-      <text x="165" y="513" class="text text-sm" style="font-family: monospace;">const title = "Feature Branch Title";</text>
+      <text x="165" y="513" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">const title = "Feature Branch Title";</text>
       
       <rect x="160" y="518" width="470" height="15" rx="2" class="warning border" opacity="0.1"/>
-      <text x="165" y="530" class="text text-sm" style="font-family: monospace;">&gt;&gt;&gt;&gt;&gt;&gt;&gt; feature/new-title (Incoming Change)</text>
+      <text x="165" y="530" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">&gt;&gt;&gt;&gt;&gt;&gt;&gt; feature/new-title (Incoming Change)</text>
     </g>
   </g>
   

--- a/docs/assets/images/diagrams/chapter05/11_stash_discard_operations.svg
+++ b/docs/assets/images/diagrams/chapter05/11_stash_discard_operations.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -89,7 +89,7 @@
       
       <!-- Stash メッセージ -->
       <rect x="170" y="310" width="200" height="20" rx="2" class="border"/>
-      <text x="175" y="325" class="text text-sm" style="font-family: monospace;">WIP: working on feature</text>
+      <text x="175" y="325" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">WIP: working on feature</text>
       
       <rect x="170" y="340" width="100" height="25" rx="4" class="primary border"/>
       <text x="220" y="357" text-anchor="middle" class="text text-sm" style="font-weight: 600;">Create Stash</text>

--- a/docs/assets/images/diagrams/chapter05/12_pull_request_creation.svg
+++ b/docs/assets/images/diagrams/chapter05/12_pull_request_creation.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -87,13 +87,13 @@
       <!-- タイトル -->
       <text x="120" y="335" class="text text-sm">Title:</text>
       <rect x="170" y="325" width="300" height="20" rx="2" class="border"/>
-      <text x="175" y="339" class="text text-sm" style="font-family: monospace;">Add user authentication feature</text>
+      <text x="175" y="339" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">Add user authentication feature</text>
       
       <!-- 説明 -->
       <text x="120" y="360" class="text text-sm">Description:</text>
       <rect x="170" y="350" width="300" height="30" rx="2" class="border"/>
-      <text x="175" y="365" class="text text-sm" style="font-family: monospace;">- Implement login/logout</text>
-      <text x="175" y="378" class="text text-sm" style="font-family: monospace;">- Add password validation</text>
+      <text x="175" y="365" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Implement login/logout</text>
+      <text x="175" y="378" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">- Add password validation</text>
       
       <!-- ベースブランチ -->
       <text x="500" y="335" class="text text-sm">Base:</text>

--- a/docs/assets/images/diagrams/chapter05/13_github_integration_features.svg
+++ b/docs/assets/images/diagrams/chapter05/13_github_integration_features.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/14_settings_preferences.svg
+++ b/docs/assets/images/diagrams/chapter05/14_settings_preferences.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/15_keyboard_shortcuts.svg
+++ b/docs/assets/images/diagrams/chapter05/15_keyboard_shortcuts.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/16_troubleshooting_common_issues.svg
+++ b/docs/assets/images/diagrams/chapter05/16_troubleshooting_common_issues.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/17_workflow_best_practices.svg
+++ b/docs/assets/images/diagrams/chapter05/17_workflow_best_practices.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter05/18_cli_vs_desktop_comparison.svg
+++ b/docs/assets/images/diagrams/chapter05/18_cli_vs_desktop_comparison.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter06/01_branch_flow_overview.svg
+++ b/docs/assets/images/diagrams/chapter06/01_branch_flow_overview.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter06/02_merge_flow_overview.svg
+++ b/docs/assets/images/diagrams/chapter06/02_merge_flow_overview.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter06/14_branch_merge_strategies.svg
+++ b/docs/assets/images/diagrams/chapter06/14_branch_merge_strategies.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter06/15_branch_history_management.svg
+++ b/docs/assets/images/diagrams/chapter06/15_branch_history_management.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -72,7 +72,7 @@
       <text x="260" y="290" class="text text-sm">• コミット統合</text>
       
       <rect x="260" y="300" width="140" height="15" rx="2" class="bg-alt border"/>
-      <text x="265" y="312" class="text text-sm" style="font-family: monospace;">git rebase -i HEAD~3</text>
+      <text x="265" y="312" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git rebase -i HEAD~3</text>
     </g>
     
     <!-- 問題2: 複雑な分岐 -->
@@ -119,10 +119,10 @@
       <text x="170" y="425" text-anchor="middle" class="text text-sm" style="font-weight: 600;">1️⃣ 現状把握</text>
       
       <rect x="110" y="440" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="115" y="452" class="text text-sm" style="font-family: monospace;">git log --oneline</text>
+      <text x="115" y="452" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git log --oneline</text>
       
       <rect x="110" y="460" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="115" y="472" class="text text-sm" style="font-family: monospace;">git log --graph</text>
+      <text x="115" y="472" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git log --graph</text>
     </g>
     
     <!-- 矢印 -->
@@ -147,10 +147,10 @@
       <text x="530" y="425" text-anchor="middle" class="text text-sm" style="font-weight: 600;">3️⃣ 実行</text>
       
       <rect x="470" y="440" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="475" y="452" class="text text-sm" style="font-family: monospace;">git rebase -i</text>
+      <text x="475" y="452" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git rebase -i</text>
       
       <rect x="470" y="460" width="120" height="15" rx="2" class="bg-alt border"/>
-      <text x="475" y="472" class="text text-sm" style="font-family: monospace;">git commit --amend</text>
+      <text x="475" y="472" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git commit --amend</text>
     </g>
     
     <!-- ステップ4: 検証 -->

--- a/docs/assets/images/diagrams/chapter06/16_branch_workflow_patterns.svg
+++ b/docs/assets/images/diagrams/chapter06/16_branch_workflow_patterns.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/01_open_source_ecosystem.svg
+++ b/docs/assets/images/diagrams/chapter07/01_open_source_ecosystem.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/01_pull_request_workflow.svg
+++ b/docs/assets/images/diagrams/chapter07/01_pull_request_workflow.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/02_code_review_process.svg
+++ b/docs/assets/images/diagrams/chapter07/02_code_review_process.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/02_project_discovery_methods.svg
+++ b/docs/assets/images/diagrams/chapter07/02_project_discovery_methods.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/03_fork_workflow_basics.svg
+++ b/docs/assets/images/diagrams/chapter07/03_fork_workflow_basics.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -101,11 +101,11 @@
       <text x="400" y="410" text-anchor="middle" class="text text-sm" style="font-weight: 600;">リポジトリ間の関係</text>
       
       <rect x="80" y="425" width="180" height="15" rx="2" class="bg border"/>
-      <text x="85" y="437" class="text text-sm" style="font-family: monospace;">git remote add upstream</text>
+      <text x="85" y="437" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git remote add upstream</text>
       <text x="270" y="437" class="text text-sm">元リポジトリ追加</text>
       
       <rect x="440" y="425" width="180" height="15" rx="2" class="bg border"/>
-      <text x="445" y="437" class="text text-sm" style="font-family: monospace;">git fetch upstream</text>
+      <text x="445" y="437" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git fetch upstream</text>
       <text x="630" y="437" class="text text-sm">最新取得</text>
     </g>
   </g>

--- a/docs/assets/images/diagrams/chapter07/04_issue_management_system.svg
+++ b/docs/assets/images/diagrams/chapter07/04_issue_management_system.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/05_contribution_guidelines.svg
+++ b/docs/assets/images/diagrams/chapter07/05_contribution_guidelines.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/06_pull_request_creation.svg
+++ b/docs/assets/images/diagrams/chapter07/06_pull_request_creation.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/07_code_review_process.svg
+++ b/docs/assets/images/diagrams/chapter07/07_code_review_process.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/08_community_etiquette.svg
+++ b/docs/assets/images/diagrams/chapter07/08_community_etiquette.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/09_license_understanding.svg
+++ b/docs/assets/images/diagrams/chapter07/09_license_understanding.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/10_documentation_contribution.svg
+++ b/docs/assets/images/diagrams/chapter07/10_documentation_contribution.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/11_testing_contribution.svg
+++ b/docs/assets/images/diagrams/chapter07/11_testing_contribution.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter07/12_long_term_engagement.svg
+++ b/docs/assets/images/diagrams/chapter07/12_long_term_engagement.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/01_issue_lifecycle.svg
+++ b/docs/assets/images/diagrams/chapter08/01_issue_lifecycle.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/01_pull_request_overview.svg
+++ b/docs/assets/images/diagrams/chapter08/01_pull_request_overview.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/02_pr_types_patterns.svg
+++ b/docs/assets/images/diagrams/chapter08/02_pr_types_patterns.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/02_project_management.svg
+++ b/docs/assets/images/diagrams/chapter08/02_project_management.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/03_pr_creation_workflow.svg
+++ b/docs/assets/images/diagrams/chapter08/03_pr_creation_workflow.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/04_pr_template_structure.svg
+++ b/docs/assets/images/diagrams/chapter08/04_pr_template_structure.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/05_pr_review_states.svg
+++ b/docs/assets/images/diagrams/chapter08/05_pr_review_states.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/06_pr_discussion_management.svg
+++ b/docs/assets/images/diagrams/chapter08/06_pr_discussion_management.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/07_pr_merge_strategies.svg
+++ b/docs/assets/images/diagrams/chapter08/07_pr_merge_strategies.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/08_pr_automation_tools.svg
+++ b/docs/assets/images/diagrams/chapter08/08_pr_automation_tools.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -104,12 +104,12 @@
       <text x="100" y="395" class="text text-sm" style="font-weight: 600;">🔧 典型的なPRワークフロー</text>
       
       <rect x="100" y="405" width="600" height="100" rx="4" class="border"/>
-      <text x="110" y="420" class="text text-sm" style="font-family: monospace;">name: PR Quality Check</text>
-      <text x="110" y="435" class="text text-sm" style="font-family: monospace;">on: pull_request</text>
-      <text x="110" y="450" class="text text-sm" style="font-family: monospace;">jobs:</text>
-      <text x="110" y="465" class="text text-sm" style="font-family: monospace;">  test: runs-on: ubuntu-latest</text>
-      <text x="110" y="480" class="text text-sm" style="font-family: monospace;">    steps: - lint - test - security-scan</text>
-      <text x="110" y="495" class="text text-sm" style="font-family: monospace;">  auto-merge: needs: test, if: author == 'dependabot'</text>
+      <text x="110" y="420" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">name: PR Quality Check</text>
+      <text x="110" y="435" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">on: pull_request</text>
+      <text x="110" y="450" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">jobs:</text>
+      <text x="110" y="465" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">  test: runs-on: ubuntu-latest</text>
+      <text x="110" y="480" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">    steps: - lint - test - security-scan</text>
+      <text x="110" y="495" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">  auto-merge: needs: test, if: author == 'dependabot'</text>
     </g>
   </g>
   

--- a/docs/assets/images/diagrams/chapter08/09_pr_conflict_resolution.svg
+++ b/docs/assets/images/diagrams/chapter08/09_pr_conflict_resolution.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }
@@ -147,16 +147,16 @@
       <text x="90" y="465" class="text text-sm" style="font-weight: 600;">主要コマンド:</text>
       
       <rect x="90" y="475" width="150" height="15" rx="2" class="border"/>
-      <text x="95" y="487" class="text text-sm" style="font-family: monospace;">git fetch upstream</text>
+      <text x="95" y="487" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git fetch upstream</text>
       
       <rect x="260" y="475" width="150" height="15" rx="2" class="border"/>
-      <text x="265" y="487" class="text text-sm" style="font-family: monospace;">git merge upstream/main</text>
+      <text x="265" y="487" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git merge upstream/main</text>
       
       <rect x="430" y="475" width="150" height="15" rx="2" class="border"/>
-      <text x="435" y="487" class="text text-sm" style="font-family: monospace;">git add resolved-file</text>
+      <text x="435" y="487" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git add resolved-file</text>
       
       <rect x="600" y="475" width="120" height="15" rx="2" class="border"/>
-      <text x="605" y="487" class="text text-sm" style="font-family: monospace;">git commit</text>
+      <text x="605" y="487" class="text text-sm" style="font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;">git commit</text>
     </g>
   </g>
   

--- a/docs/assets/images/diagrams/chapter08/10_pr_quality_gates.svg
+++ b/docs/assets/images/diagrams/chapter08/10_pr_quality_gates.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/11_pr_metrics_analysis.svg
+++ b/docs/assets/images/diagrams/chapter08/11_pr_metrics_analysis.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/12_pr_branch_protection.svg
+++ b/docs/assets/images/diagrams/chapter08/12_pr_branch_protection.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/13_pr_team_workflows.svg
+++ b/docs/assets/images/diagrams/chapter08/13_pr_team_workflows.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter08/14_pr_best_practices_summary.svg
+++ b/docs/assets/images/diagrams/chapter08/14_pr_best_practices_summary.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/01_common_errors_overview.svg
+++ b/docs/assets/images/diagrams/chapter10/01_common_errors_overview.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/02_authentication_troubleshooting.svg
+++ b/docs/assets/images/diagrams/chapter10/02_authentication_troubleshooting.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/03_network_connection_issues.svg
+++ b/docs/assets/images/diagrams/chapter10/03_network_connection_issues.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/04_git_operation_errors.svg
+++ b/docs/assets/images/diagrams/chapter10/04_git_operation_errors.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/05_configuration_environment_issues.svg
+++ b/docs/assets/images/diagrams/chapter10/05_configuration_environment_issues.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/06_diagnostic_tools_usage.svg
+++ b/docs/assets/images/diagrams/chapter10/06_diagnostic_tools_usage.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/07_repository_corruption_recovery.svg
+++ b/docs/assets/images/diagrams/chapter10/07_repository_corruption_recovery.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/08_merge_conflict_resolution.svg
+++ b/docs/assets/images/diagrams/chapter10/08_merge_conflict_resolution.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/09_branch_management_issues.svg
+++ b/docs/assets/images/diagrams/chapter10/09_branch_management_issues.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/10_remote_synchronization_problems.svg
+++ b/docs/assets/images/diagrams/chapter10/10_remote_synchronization_problems.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/11_file_permission_access_issues.svg
+++ b/docs/assets/images/diagrams/chapter10/11_file_permission_access_issues.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/12_data_recovery_backup_strategies.svg
+++ b/docs/assets/images/diagrams/chapter10/12_data_recovery_backup_strategies.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/13_performance_optimization.svg
+++ b/docs/assets/images/diagrams/chapter10/13_performance_optimization.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/14_security_issue_handling.svg
+++ b/docs/assets/images/diagrams/chapter10/14_security_issue_handling.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/15_team_collaboration_troubleshooting.svg
+++ b/docs/assets/images/diagrams/chapter10/15_team_collaboration_troubleshooting.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter10/16_prevention_best_practices.svg
+++ b/docs/assets/images/diagrams/chapter10/16_prevention_best_practices.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/01_portfolio_importance.svg
+++ b/docs/assets/images/diagrams/chapter11/01_portfolio_importance.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/02_profile_optimization.svg
+++ b/docs/assets/images/diagrams/chapter11/02_profile_optimization.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/03_repository_showcase_strategy.svg
+++ b/docs/assets/images/diagrams/chapter11/03_repository_showcase_strategy.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/04_readme_effective_writing.svg
+++ b/docs/assets/images/diagrams/chapter11/04_readme_effective_writing.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/05_activity_contribution_visualization.svg
+++ b/docs/assets/images/diagrams/chapter11/05_activity_contribution_visualization.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/06_project_documentation_strategy.svg
+++ b/docs/assets/images/diagrams/chapter11/06_project_documentation_strategy.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/07_skill_technology_demonstration.svg
+++ b/docs/assets/images/diagrams/chapter11/07_skill_technology_demonstration.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/08_networking_community_building.svg
+++ b/docs/assets/images/diagrams/chapter11/08_networking_community_building.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/09_portfolio_maintenance_evolution.svg
+++ b/docs/assets/images/diagrams/chapter11/09_portfolio_maintenance_evolution.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/chapter11/10_career_development_utilization.svg
+++ b/docs/assets/images/diagrams/chapter11/10_career_development_utilization.svg
@@ -3,7 +3,7 @@
     <style>
       .bg { fill: #ffffff; }
       .bg-alt { fill: #f8fafc; }
-      .text { fill: #1e293b; font-family: system-ui, sans-serif; }
+      .text { fill: #1e293b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; }
       .text-sm { font-size: 12px; }
       .text-md { font-size: 14px; font-weight: 500; }
       .border { stroke: #e2e8f0; fill: none; stroke-width: 1; }

--- a/docs/assets/images/diagrams/git-branching-strategies.svg
+++ b/docs/assets/images/diagrams/git-branching-strategies.svg
@@ -16,10 +16,10 @@
         --svg-error: #DC2626;
         --svg-neutral: #6B7280;
       }
-      .title-text { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
-      .flow-title { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: white; }
-      .branch-text { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
-      .label-text { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-text-secondary); }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .flow-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: white; }
+      .branch-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .label-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: var(--svg-text-secondary); }
       .main-branch { stroke: var(--svg-primary); stroke-width: 3; fill: none; }
       .develop-branch { stroke: var(--svg-success); stroke-width: 2; fill: none; }
       .feature-branch { stroke: var(--svg-warning); stroke-width: 2; fill: none; stroke-dasharray: 5,3; }

--- a/docs/assets/images/diagrams/git-workflow.svg
+++ b/docs/assets/images/diagrams/git-workflow.svg
@@ -2,11 +2,11 @@
 <svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .stage-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
-      .branch-text { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; fill: #2c3e50; font-weight: bold; }
-      .command-text { font-family: 'Courier New', monospace; font-size: 10px; fill: #2c3e50; }
-      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .stage-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: bold; fill: #fff; }
+      .branch-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; fill: #2c3e50; font-weight: bold; }
+      .command-text { font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-size: 10px; fill: #2c3e50; }
+      .small-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #7f8c8d; }
       .workspace-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
       .staging-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }
       .local-repo-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }

--- a/docs/assets/images/diagrams/github-collaboration.svg
+++ b/docs/assets/images/diagrams/github-collaboration.svg
@@ -2,12 +2,12 @@
 <svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .section-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #2c3e50; }
-      .process-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #fff; }
-      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
-      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
-      .code-text { font-family: 'Courier New', monospace; font-size: 10px; fill: #2c3e50; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: bold; fill: #2c3e50; }
+      .process-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: bold; fill: #fff; }
+      .text-content { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #7f8c8d; }
+      .code-text { font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace; font-size: 10px; fill: #2c3e50; }
       .fork-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
       .clone-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
       .pr-box { fill: #e74c3c; stroke: #c0392b; stroke-width: 2; }

--- a/docs/assets/images/diagrams/github-features.svg
+++ b/docs/assets/images/diagrams/github-features.svg
@@ -2,11 +2,11 @@
 <svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .feature-title { font-family: 'Noto Sans JP', sans-serif; font-size: 14px; font-weight: bold; fill: #fff; }
-      .section-title { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; font-weight: bold; fill: #2c3e50; }
-      .text-content { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #2c3e50; }
-      .small-text { font-family: 'Noto Sans JP', sans-serif; font-size: 10px; fill: #7f8c8d; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .feature-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 14px; font-weight: bold; fill: #fff; }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: bold; fill: #2c3e50; }
+      .text-content { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #2c3e50; }
+      .small-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; fill: #7f8c8d; }
       .repo-box { fill: #3498db; stroke: #2980b9; stroke-width: 2; }
       .project-box { fill: #2ecc71; stroke: #27ae60; stroke-width: 2; }
       .wiki-box { fill: #f39c12; stroke: #e67e22; stroke-width: 2; }


### PR DESCRIPTION
## 変更内容
SVG 図表内の `font-family` 指定を、書籍共通のフォントスタック（`--font-sans` / `--font-mono` 相当）に統一しました。

- 対象: `docs/**/*.svg`
- 変更: `system-ui, sans-serif` / `monospace` / `Courier New` / `'Noto Sans JP', sans-serif` 等を正規化
- 実行: `book-formatter/scripts/svg-font-normalize.js docs --apply`

## 補足
このPRは SVG 内の `font-family` のみを機械的に置換しています（図形/レイアウトには触れていません）。
