### PR TITLE
Fix #211: add reading routes and series links

### DIFF
--- a/docs/appendices/appendix-resources/index.md
+++ b/docs/appendices/appendix-resources/index.md
@@ -301,6 +301,18 @@ order: 102
 
 ---
 
+## C.13 シリーズ内の次の一冊
+
+外部リソースに進む前に、ITDO の関連書籍で次のテーマを補強する選択肢もあります。
+
+| 次に読みたいテーマ | 書籍 | URL | 活用場面 |
+|---|---|---|---|
+| GitHub を使った日常運用の標準化 | GitHub Workflow実践ガイド | https://itdojp.github.io/github-workflow-book/ | ブランチ運用、レビュー、リリース運用を整理したいとき |
+| Issue / PR ベースの仕事の進め方 | Issue駆動仕事術 | https://itdojp.github.io/issue-driven-work-book/ | タスク分解、進捗可視化、非同期コラボレーションを強化したいとき |
+| README / Runbook / 手順書の整備 | エンジニアのためのドキュメント設計入門 | https://itdojp.github.io/engineering-documentation-book/ | Docs-as-Code をチーム文書運用へ広げたいとき |
+
+---
+
 この学習リソース集を活用して、GitHub の理解と実践スキルを継続的に向上させてください。技術は常に進歩しているため、定期的な学習と実践を通じて最新の知識とスキルを身につけることが重要です。
 
 **継続学習のコツ：**

--- a/docs/chapters/chapter-introduction/index.md
+++ b/docs/chapters/chapter-introduction/index.md
@@ -147,6 +147,13 @@ GitHubを使った一般的な開発ワークフローを理解することで�
 
 難しく感じる部分があっても心配ありません。実際に操作してみることで、概念が具体的にイメージできるようになります。
 
+## 次の一歩
+
+- 標準ルートで進める場合は、[第2章：Git基礎 - バージョン管理の仕組み]({{ '/chapters/chapter-git-basics/' | relative_url }}) に進んでください。
+- 文書運用を先に試したい場合は、[特別編：Docs-as-Code]({{ '/chapters/chapter-docs-as-code/' | relative_url }}) を先に読んでも構いません。
+- コマンドを見ながら進めたい場合は、[付録A：Gitコマンドリファレンス]({{ '/appendices/appendix-git-commands-reference/' | relative_url }}) を手元に開いておくと迷いにくくなります。
+- チーム開発の流れを先に見たい場合は、[第7章：ブランチの基本操作]({{ '/chapters/chapter-branch-operations/' | relative_url }}) と [第8章：Issue管理とプロジェクト管理]({{ '/chapters/chapter-issue-management/' | relative_url }}) を参照してください。
+
 ---
 
 **学習を始める前に**：この書籍は「完璧に理解してから次に進む」必要はありません。「なんとなくわかった」程度で次の章に進み、実際の操作を通じて理解を深めていくアプローチを推奨します。

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,17 @@ permalink: /
 - チーム開発のフローを急ぎ把握したい読者は、第5〜8章（リポジトリ管理・ブランチ運用・Pull Request・Issues）を先に読み、実務のイメージがついたところで基礎章に戻る読み方も有効である。
 - 自動化やセキュリティに関心が高い読者は、第9〜11章を重点的に読み、付録（Gitコマンドリファレンス・ショートカット集・参考リソース）を手元の辞書として使うことを想定している。
 
+## 課題別の最短ルート
+
+- **Git と GitHub を最短で一周したい**  
+  [第1章]({{ '/chapters/chapter-introduction/' | relative_url }}) → [第2章]({{ '/chapters/chapter-git-basics/' | relative_url }}) → [第3章]({{ '/chapters/chapter-repository-creation/' | relative_url }}) → [付録A]({{ '/appendices/appendix-git-commands-reference/' | relative_url }})
+- **文書管理や社内ナレッジ運用に使いたい**  
+  [第1章]({{ '/chapters/chapter-introduction/' | relative_url }}) → [特別編：Docs-as-Code]({{ '/chapters/chapter-docs-as-code/' | relative_url }}) → [第8章]({{ '/chapters/chapter-issue-management/' | relative_url }}) → [付録C]({{ '/appendices/appendix-resources/' | relative_url }})
+- **チーム開発の流れを先に把握したい**  
+  [第1章]({{ '/chapters/chapter-introduction/' | relative_url }}) → [第7章]({{ '/chapters/chapter-branch-operations/' | relative_url }}) → [第8章]({{ '/chapters/chapter-issue-management/' | relative_url }}) → [第12章]({{ '/chapters/chapter-troubleshooting/' | relative_url }})
+- **GitHub Actions とセキュリティまで早めに見たい**  
+  [第1章]({{ '/chapters/chapter-introduction/' | relative_url }}) → [第9章]({{ '/chapters/chapter-github-actions/' | relative_url }}) → [第10章]({{ '/chapters/chapter-security-best-practices/' | relative_url }}) → [付録C]({{ '/appendices/appendix-resources/' | relative_url }})
+
 ## 所要時間
 - 通読: 約6〜12時間（本文量ベース概算。400〜600文字/分換算）
 - 演習込み: 約12〜24時間（Git/GitHub の実操作・環境構築の進度により変動）
@@ -107,6 +118,15 @@ permalink: /
 2. **実際に手を動かす** - サンプルコードは必ず実行してみましょう
 3. **実習を活用する** - `examples/`（実習サンプル）で練習：**[実習サンプル]({{ '/examples/' | relative_url }})**
 4. **コミュニティに参加** - 分からないことは積極的に質問しましょう
+
+## シリーズ内の次の一冊
+
+- **実務の標準フローを整理したい**  
+  [GitHub Workflow実践ガイド](https://itdojp.github.io/github-workflow-book/) で、日常運用のブランチ戦略やレビュー運用を補強できます。
+- **Issue / PR ベースの進め方を深掘りしたい**  
+  [Issue駆動仕事術](https://itdojp.github.io/issue-driven-work-book/) で、Issue 分解や進捗管理を学べます。
+- **README / Runbook / 手順書の整備までつなげたい**  
+  [エンジニアのためのドキュメント設計入門](https://itdojp.github.io/engineering-documentation-book/) で、Docs-as-Code と文書運用を補強できます。
 
 ## ライセンス
 

--- a/manuscript/appendix-resources/index.md
+++ b/manuscript/appendix-resources/index.md
@@ -301,6 +301,18 @@ order: 102
 
 ---
 
+## C.13 シリーズ内の次の一冊
+
+外部リソースに進む前に、ITDO の関連書籍で次のテーマを補強する選択肢もあります。
+
+| 次に読みたいテーマ | 書籍 | URL | 活用場面 |
+|---|---|---|---|
+| GitHub を使った日常運用の標準化 | GitHub Workflow実践ガイド | https://itdojp.github.io/github-workflow-book/ | ブランチ運用、レビュー、リリース運用を整理したいとき |
+| Issue / PR ベースの仕事の進め方 | Issue駆動仕事術 | https://itdojp.github.io/issue-driven-work-book/ | タスク分解、進捗可視化、非同期コラボレーションを強化したいとき |
+| README / Runbook / 手順書の整備 | エンジニアのためのドキュメント設計入門 | https://itdojp.github.io/engineering-documentation-book/ | Docs-as-Code をチーム文書運用へ広げたいとき |
+
+---
+
 この学習リソース集を活用して、GitHub の理解と実践スキルを継続的に向上させてください。技術は常に進歩しているため、定期的な学習と実践を通じて最新の知識とスキルを身につけることが重要です。
 
 **継続学習のコツ：**

--- a/manuscript/chapter-introduction/index.md
+++ b/manuscript/chapter-introduction/index.md
@@ -147,6 +147,13 @@ GitHubを使った一般的な開発ワークフローを理解することで�
 
 難しく感じる部分があっても心配ありません。実際に操作してみることで、概念が具体的にイメージできるようになります。
 
+## 次の一歩
+
+- 標準ルートで進める場合は、[第2章：Git基礎 - バージョン管理の仕組み]({{ '/chapters/chapter-git-basics/' | relative_url }}) に進んでください。
+- 文書運用を先に試したい場合は、[特別編：Docs-as-Code]({{ '/chapters/chapter-docs-as-code/' | relative_url }}) を先に読んでも構いません。
+- コマンドを見ながら進めたい場合は、[付録A：Gitコマンドリファレンス]({{ '/appendices/appendix-git-commands-reference/' | relative_url }}) を手元に開いておくと迷いにくくなります。
+- チーム開発の流れを先に見たい場合は、[第7章：ブランチの基本操作]({{ '/chapters/chapter-branch-operations/' | relative_url }}) と [第8章：Issue管理とプロジェクト管理]({{ '/chapters/chapter-issue-management/' | relative_url }}) を参照してください。
+
 ---
 
 **学習を始める前に**：この書籍は「完璧に理解してから次に進む」必要はありません。「なんとなくわかった」程度で次の章に進み、実際の操作を通じて理解を深めていくアプローチを推奨します。


### PR DESCRIPTION
## 概要
- トップに課題別の最短読書ルートを追加
- 付録Cにシリーズ内の次の一冊を追加
- 導入章の末尾に次の一歩を追加
- `manuscript/**` にも同内容を反映し、公開サイトとの乖離を防止

## 変更ファイル
- `docs/index.md`
- `docs/chapters/chapter-introduction/index.md`
- `docs/appendices/appendix-resources/index.md`
- `manuscript/chapter-introduction/index.md`
- `manuscript/appendix-resources/index.md`

## 検証
- `python3 scripts/check_markdown_internal_links.py docs/index.md docs/chapters/chapter-introduction/index.md docs/appendices/appendix-resources/index.md manuscript/chapter-introduction/index.md manuscript/appendix-resources/index.md`
- 関連書籍 URL の HTTP 200 確認

Closes #211