### PR TITLE
Fix docs-as-code manuscript links

### DIFF
--- a/manuscript/chapter-docs-as-code/index.md
+++ b/manuscript/chapter-docs-as-code/index.md
@@ -191,7 +191,7 @@ Issue/Project のラベル体系は、タスク管理だけでなく **情報分
 Issue と Pull Request の基本操作は、以下の章も参照してください。
 
 - Pull Request：{{ '/chapters/chapter-branch-operations/' | relative_url }}
-- Issue / Projects：{{ '/src/chapter-issue-management/' | relative_url }}
+- Issue / Projects：{{ '/chapters/chapter-issue-management/' | relative_url }}
 
 ### 手順（エンジニア向け：ローカルで Git を使う）
 
@@ -220,7 +220,7 @@ git push -u origin docs/add-templates
 
 関連する章：
 
-- GitHub Actions：{{ '/src/chapter-github-actions/' | relative_url }}
+- GitHub Actions：{{ '/chapters/chapter-github-actions/' | relative_url }}
 
 ## まとめ
 


### PR DESCRIPTION
## Summary
- replace leftover `/src/...` links in the Docs-as-Code manuscript chapter with the published chapter paths
- keep the manuscript navigation aligned with the already-correct docs output

## Verification
- git diff --check
- npm ci
- npx markdownlint-cli manuscript/chapter-docs-as-code/index.md
- python3 scripts/check_markdown_internal_links.py manuscript/chapter-docs-as-code/index.md
- python3 scripts/check_bidi_unicode.py