### PR TITLE
fix: align UX flags with published modules

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -93,10 +93,10 @@
       "readingGuide": true,
       "checklistPack": false,
       "troubleshootingFlow": false,
-      "conceptMap": true,
+      "conceptMap": false,
       "figureIndex": false,
       "legalNotice": true,
-      "glossary": true
+      "glossary": false
     }
   },
   "shared": {


### PR DESCRIPTION
## Summary

Align UX metadata with the actual reader-facing modules audited for portfolio Sprint itdojp/it-engineer-knowledge-architecture#226.

- conceptMap: true → false; the chapter-1 learning-roadmap figure is not an independent concept-map module
- glossary: true → false; no dedicated glossary page or navigation exists
- retain quickStart / readingGuide / legalNotice because the public top exposes the 15-minute task routes, reading guide, and license section
- track the missing Profile A glossary in portal #227; concept map remains a recommended-module improvement

## Verification

- npm ci
- npm test
- npm run docs:quality-gate
- npm run build
- npm audit --audit-level=moderate (0 vulnerabilities)
- git diff --check

Existing Ruby/Sass build warnings are tracked separately in #225.

Closes #226
