### PR TITLE
docs: explain pull_request_target trust boundary

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Check reader-facing glossary contract
         run: node scripts/check-glossary-contract.js
 
+      - name: Check GitHub Actions trigger trust boundary
+        run: |
+          node scripts/check-github-actions-trust-boundary.js
+          node scripts/check-github-actions-trust-boundary.js --self-test
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci

--- a/docs/chapters/chapter-github-actions/index.md
+++ b/docs/chapters/chapter-github-actions/index.md
@@ -121,6 +121,9 @@ jobs:
 workflow の各 job では、GitHub が一時的な `GITHUB_TOKEN` を自動発行します。通常の CI では、まず読み取り中心の権限から始め、必要な job だけに追加権限を与えます。
 
 ```yaml
+on:
+  pull_request:
+
 permissions:
   contents: read
 
@@ -131,6 +134,10 @@ jobs:
       - uses: actions/checkout@v6
       - run: npm test
 ```
+
+fork からの Pull Request を検証する基本形は、`pull_request` と `contents: read` の組み合わせです。
+public repository の fork PR では、既定で `GITHUB_TOKEN` は read-only になり、通常の repository secrets は渡りません。
+private repository では管理設定により write token や secrets を送れるため、repository settings も確認してください。
 
 Pull Request へコメントを書く、Pages へデプロイする、packages を発行するなどの操作では追加権限が必要です。その場合も、workflow 全体へ広い権限を付けるのではなく、対象 job に必要な権限だけを付与します。
 
@@ -184,8 +191,23 @@ YAML はインデント（空白）に敏感です。コピペ後に動かない
 ### Secrets とトリガー（事故防止）
 
 - **Secrets をログに出さない**: `echo` や `set -x`（シェルのデバッグ出力）で漏洩しやすくなります。
-- **fork からの Pull Request**: 原則として Secrets は渡りません（安全のため）。この制約を回避しようとして危険なトリガー（例: `pull_request_target`）を安易に使わないでください。
+- **fork からの Pull Request**: 基本は`pull_request`とread-onlyのminimum `permissions`です。public repositoryでは通常Secretsを渡しません。
+- **`pull_request_target`の境界**: base repositoryのdefault branchにあるworkflowをbase branch contextで実行し、base側の`GITHUB_TOKEN`とrepository / organization secretsへ到達できます。
+- **fork承認を安全装置にしない**: public repositoryの`pull_request_target`はfork workflowの承認設定に依存せずbase側で実行されるため、初回contributor承認で停止すると期待してはいけません。
+- **untrusted head codeを実行しない**: `pull_request_target`で`github.event.pull_request.head.sha`をcheckoutし、build、test、install script、任意commandを実行してはいけません。label付与などmetadataだけを扱う場合も、PR codeをcheckout/実行しないことを確認します。
 - **AI/外部サービスへログを貼らない**: 失敗ログにはトークン、URL、内部パス、顧客情報が混ざることがあります。共有前にマスクし、必要最小限だけ貼り付けます。
+
+公式の境界は、[Securely using `pull_request_target`](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)、[Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)、[Workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)、[Managing GitHub Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)で確認します。
+
+### privileged writeが必要な場合の2-stage設計
+
+1. 第1段は`pull_request`で実行し、`contents: read`、Secretsなしでuntrusted PR codeを検証します。
+2. 第2段は`workflow_run`または手動承認で起動し、PR codeをcheckout/実行せず、write操作だけを行います。
+3. 前段artifactを使う場合はuntrusted dataとして扱い、schema、size、対象PR、producer run、digestを検証します。展開先はworkspaceではなく`runner.temp`配下に限定します。
+4. 後段ではartifact内のscriptやbinaryを実行せず、検証済みのmetadataだけをAPI writeへ渡します。
+
+`workflow_run`は自動的に安全になる仕組みではありません。
+後段でPR codeや未検証artifactを実行すると、低権限とprivileged処理を分けた意味が失われます。
 
 ### ログの読み方（最短）
 
@@ -217,6 +239,7 @@ YAML はインデント（空白）に敏感です。コピペ後に動かない
 1. `npm test` に加えて `npm run lint` を回す
 2. Pull Request の必須チェックに CI を設定する（ブランチ保護）
 3. Secrets を使う場合は、対象ブランチ/イベントとログ出力の扱いを見直す（最小権限）
+4. fork PRは`pull_request`で検証し、writeが必要ならPR codeを実行しない2-stageへ分離する
 
 **理解度確認：**
 □ GitHub Actionsの基本概念を理解している  

--- a/manuscript/chapter-github-actions/index.md
+++ b/manuscript/chapter-github-actions/index.md
@@ -121,6 +121,9 @@ jobs:
 workflow の各 job では、GitHub が一時的な `GITHUB_TOKEN` を自動発行します。通常の CI では、まず読み取り中心の権限から始め、必要な job だけに追加権限を与えます。
 
 ```yaml
+on:
+  pull_request:
+
 permissions:
   contents: read
 
@@ -131,6 +134,10 @@ jobs:
       - uses: actions/checkout@v6
       - run: npm test
 ```
+
+fork からの Pull Request を検証する基本形は、`pull_request` と `contents: read` の組み合わせです。
+public repository の fork PR では、既定で `GITHUB_TOKEN` は read-only になり、通常の repository secrets は渡りません。
+private repository では管理設定により write token や secrets を送れるため、repository settings も確認してください。
 
 Pull Request へコメントを書く、Pages へデプロイする、packages を発行するなどの操作では追加権限が必要です。その場合も、workflow 全体へ広い権限を付けるのではなく、対象 job に必要な権限だけを付与します。
 
@@ -184,8 +191,23 @@ YAML はインデント（空白）に敏感です。コピペ後に動かない
 ### Secrets とトリガー（事故防止）
 
 - **Secrets をログに出さない**: `echo` や `set -x`（シェルのデバッグ出力）で漏洩しやすくなります。
-- **fork からの Pull Request**: 原則として Secrets は渡りません（安全のため）。この制約を回避しようとして危険なトリガー（例: `pull_request_target`）を安易に使わないでください。
+- **fork からの Pull Request**: 基本は`pull_request`とread-onlyのminimum `permissions`です。public repositoryでは通常Secretsを渡しません。
+- **`pull_request_target`の境界**: base repositoryのdefault branchにあるworkflowをbase branch contextで実行し、base側の`GITHUB_TOKEN`とrepository / organization secretsへ到達できます。
+- **fork承認を安全装置にしない**: public repositoryの`pull_request_target`はfork workflowの承認設定に依存せずbase側で実行されるため、初回contributor承認で停止すると期待してはいけません。
+- **untrusted head codeを実行しない**: `pull_request_target`で`github.event.pull_request.head.sha`をcheckoutし、build、test、install script、任意commandを実行してはいけません。label付与などmetadataだけを扱う場合も、PR codeをcheckout/実行しないことを確認します。
 - **AI/外部サービスへログを貼らない**: 失敗ログにはトークン、URL、内部パス、顧客情報が混ざることがあります。共有前にマスクし、必要最小限だけ貼り付けます。
+
+公式の境界は、[Securely using `pull_request_target`](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)、[Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)、[Workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)、[Managing GitHub Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)で確認します。
+
+### privileged writeが必要な場合の2-stage設計
+
+1. 第1段は`pull_request`で実行し、`contents: read`、Secretsなしでuntrusted PR codeを検証します。
+2. 第2段は`workflow_run`または手動承認で起動し、PR codeをcheckout/実行せず、write操作だけを行います。
+3. 前段artifactを使う場合はuntrusted dataとして扱い、schema、size、対象PR、producer run、digestを検証します。展開先はworkspaceではなく`runner.temp`配下に限定します。
+4. 後段ではartifact内のscriptやbinaryを実行せず、検証済みのmetadataだけをAPI writeへ渡します。
+
+`workflow_run`は自動的に安全になる仕組みではありません。
+後段でPR codeや未検証artifactを実行すると、低権限とprivileged処理を分けた意味が失われます。
 
 ### ログの読み方（最短）
 
@@ -217,6 +239,7 @@ YAML はインデント（空白）に敏感です。コピペ後に動かない
 1. `npm test` に加えて `npm run lint` を回す
 2. Pull Request の必須チェックに CI を設定する（ブランチ保護）
 3. Secrets を使う場合は、対象ブランチ/イベントとログ出力の扱いを見直す（最小権限）
+4. fork PRは`pull_request`で検証し、writeが必要ならPR codeを実行しない2-stageへ分離する
 
 **理解度確認：**
 □ GitHub Actionsの基本概念を理解している  

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "bundle exec jekyll serve --livereload --config docs/_config.yml --source docs --destination _site",
     "build": "bundle exec jekyll build --config docs/_config.yml --source docs --destination _site",
-    "test": "npm run check:metadata && npm run check:glossary && npm run lint && npm run check-links",
+    "test": "npm run check:metadata && npm run check:glossary && npm run check:actions-trust-boundary && npm run check:actions-trust-boundary:self-test && npm run lint && npm run check-links",
     "lint": "markdownlint --config .markdownlint-src.json src/**/*.md",
     "check-links": "markdown-link-check src/**/*.md",
     "docs:lint": "markdownlint 'docs/**/*.md'",
@@ -14,7 +14,9 @@
     "docs:quality-gate": "npm run docs:lint && npm run docs:check-internal-links",
     "deploy": "gh-pages -d _site",
     "check:metadata": "node scripts/check-metadata-consistency.js",
-    "check:glossary": "node scripts/check-glossary-contract.js"
+    "check:glossary": "node scripts/check-glossary-contract.js",
+    "check:actions-trust-boundary": "node scripts/check-github-actions-trust-boundary.js",
+    "check:actions-trust-boundary:self-test": "node scripts/check-github-actions-trust-boundary.js --self-test"
   },
   "keywords": [
     "book",

--- a/scripts/check-github-actions-trust-boundary.js
+++ b/scripts/check-github-actions-trust-boundary.js
@@ -10,6 +10,15 @@ function normalize(value) {
   return value.replace(/\r\n?/g, '\n');
 }
 
+function readRequired(file) {
+  try {
+    return normalize(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    console.error(`GitHub Actions trust-boundary contract failed: ${file}を読み込めません (${error.code ?? error.message})`);
+    process.exit(1);
+  }
+}
+
 function validate(content) {
   const errors = [];
   const required = [
@@ -46,7 +55,7 @@ function validate(content) {
   if (yamlBlocks.some((block) => block.includes('pull_request_target:'))) {
     errors.push('copy可能なYAML例にpull_request_targetを含めてはいけません');
   }
-  if (/permissions:\s*(?:write-all|read-all)/.test(content) || /contents:\s*write/.test(content)) {
+  if (yamlBlocks.some((block) => /permissions:\s*(?:write-all|read-all)/.test(block) || /contents:\s*write/.test(block))) {
     errors.push('基本例へ広いwrite権限を付与してはいけません');
   }
   return errors;
@@ -61,19 +70,28 @@ function expectRejected(content, name, mutate, expected) {
   }
 }
 
-const manuscript = normalize(fs.readFileSync(manuscriptPath, 'utf8'));
-const docs = normalize(fs.readFileSync(docsPath, 'utf8'));
+function expectAccepted(content, name, mutate) {
+  const mutated = mutate(content);
+  if (mutated === content) throw new Error(`self-test ${name}: mutation対象がありません`);
+  const errors = validate(mutated);
+  if (errors.length) {
+    throw new Error(`self-test ${name}: 安全な説明を許容できません (${errors.join('; ')})`);
+  }
+}
+
+const manuscript = readRequired(manuscriptPath);
+const docs = readRequired(docsPath);
 const errors = [
   ...validate(manuscript).map((error) => `${manuscriptPath}: ${error}`),
   ...validate(docs).map((error) => `${docsPath}: ${error}`),
 ];
 if (manuscript !== docs) errors.push(`${manuscriptPath} and ${docsPath}: mirror content differs`);
 
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const packageJson = JSON.parse(readRequired('package.json'));
 for (const command of ['npm run check:actions-trust-boundary', 'npm run check:actions-trust-boundary:self-test']) {
   if (!packageJson.scripts?.test?.includes(command)) errors.push(`npm test must run ${command}`);
 }
-const workflow = normalize(fs.readFileSync('.github/workflows/book-qa.yml', 'utf8'));
+const workflow = readRequired('.github/workflows/book-qa.yml');
 for (const command of [
   'node scripts/check-github-actions-trust-boundary.js',
   'node scripts/check-github-actions-trust-boundary.js --self-test',
@@ -95,6 +113,7 @@ if (process.argv.includes('--self-test')) {
   expectRejected(manuscript, 'missing head-code ban', (value) => value.replace('任意commandを実行してはいけません', '任意commandを実行できます'), '任意command');
   expectRejected(manuscript, 'missing two-stage validation', (value) => value.replace('schema、size、対象PR、producer run、digestを検証', 'artifactを利用'), 'schema、size');
   expectRejected(manuscript, 'missing official source', (value) => value.replace('https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target', 'https://example.invalid'), 'securely-using');
+  expectAccepted(manuscript, 'write permission warning in prose', (value) => `${value}\n\n説明文ではcontents: writeの危険性を明示できます。`);
   console.log('GitHub Actions trust-boundary contract self-test passed.');
 } else {
   console.log('GitHub Actions trust-boundary contract passed: fork PR, privileged context, and two-stage boundaries.');

--- a/scripts/check-github-actions-trust-boundary.js
+++ b/scripts/check-github-actions-trust-boundary.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+
+const manuscriptPath = 'manuscript/chapter-github-actions/index.md';
+const docsPath = 'docs/chapters/chapter-github-actions/index.md';
+
+function normalize(value) {
+  return value.replace(/\r\n?/g, '\n');
+}
+
+function validate(content) {
+  const errors = [];
+  const required = [
+    'on:\n  pull_request:',
+    'permissions:\n  contents: read',
+    'fork からの Pull Request を検証する基本形',
+    'public repository の fork PR では、既定で `GITHUB_TOKEN` は read-only',
+    'private repository では管理設定により write token や secrets を送れる',
+    '`pull_request_target`の境界',
+    '`pull_request_target`はfork workflowの承認設定に依存せず',
+    'base repositoryのdefault branch',
+    'base branch context',
+    '`github.event.pull_request.head.sha`をcheckoutし',
+    '任意commandを実行してはいけません',
+    'PR codeをcheckout/実行しない',
+    'privileged writeが必要な場合の2-stage設計',
+    '`workflow_run`または手動承認',
+    'schema、size、対象PR、producer run、digestを検証',
+    '`runner.temp`配下',
+    'artifact内のscriptやbinaryを実行せず',
+    'https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target',
+    'https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows',
+    'https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax',
+    'https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository',
+  ];
+  for (const marker of required) {
+    if (!content.includes(marker)) errors.push(`必須markerがありません: ${marker}`);
+  }
+
+  const yamlBlocks = [...content.matchAll(/```yaml\n([\s\S]*?)\n```/g)].map((match) => match[1]);
+  if (!yamlBlocks.some((block) => block.includes('pull_request:') && block.includes('contents: read'))) {
+    errors.push('pull_request + contents: readの安全な基本例がありません');
+  }
+  if (yamlBlocks.some((block) => block.includes('pull_request_target:'))) {
+    errors.push('copy可能なYAML例にpull_request_targetを含めてはいけません');
+  }
+  if (/permissions:\s*(?:write-all|read-all)/.test(content) || /contents:\s*write/.test(content)) {
+    errors.push('基本例へ広いwrite権限を付与してはいけません');
+  }
+  return errors;
+}
+
+function expectRejected(content, name, mutate, expected) {
+  const mutated = mutate(content);
+  if (mutated === content) throw new Error(`self-test ${name}: mutation対象がありません`);
+  const errors = validate(mutated);
+  if (!errors.some((error) => error.includes(expected))) {
+    throw new Error(`self-test ${name}: 違反を拒否できません (${errors.join('; ')})`);
+  }
+}
+
+const manuscript = normalize(fs.readFileSync(manuscriptPath, 'utf8'));
+const docs = normalize(fs.readFileSync(docsPath, 'utf8'));
+const errors = [
+  ...validate(manuscript).map((error) => `${manuscriptPath}: ${error}`),
+  ...validate(docs).map((error) => `${docsPath}: ${error}`),
+];
+if (manuscript !== docs) errors.push(`${manuscriptPath} and ${docsPath}: mirror content differs`);
+
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+for (const command of ['npm run check:actions-trust-boundary', 'npm run check:actions-trust-boundary:self-test']) {
+  if (!packageJson.scripts?.test?.includes(command)) errors.push(`npm test must run ${command}`);
+}
+const workflow = normalize(fs.readFileSync('.github/workflows/book-qa.yml', 'utf8'));
+for (const command of [
+  'node scripts/check-github-actions-trust-boundary.js',
+  'node scripts/check-github-actions-trust-boundary.js --self-test',
+]) {
+  if (!workflow.includes(command)) errors.push(`Book QA must run ${command}`);
+}
+
+if (errors.length) {
+  console.error('GitHub Actions trust-boundary contract failed:');
+  errors.forEach((error) => console.error(`- ${error}`));
+  process.exit(1);
+}
+
+if (process.argv.includes('--self-test')) {
+  expectRejected(manuscript, 'missing pull_request', (value) => value.replace('on:\n  pull_request:', 'on:\n  push:'), 'pull_request:');
+  expectRejected(manuscript, 'broad write', (value) => value.replace('contents: read', 'contents: write'), 'write権限');
+  expectRejected(manuscript, 'unsafe target YAML', (value) => value.replace('pull_request:', 'pull_request_target:'), 'pull_request_target');
+  expectRejected(manuscript, 'missing fork approval boundary', (value) => value.replace('`pull_request_target`はfork workflowの承認設定に依存せず', '`pull_request_target`は承認後に実行され'), '承認設定に依存せず');
+  expectRejected(manuscript, 'missing head-code ban', (value) => value.replace('任意commandを実行してはいけません', '任意commandを実行できます'), '任意command');
+  expectRejected(manuscript, 'missing two-stage validation', (value) => value.replace('schema、size、対象PR、producer run、digestを検証', 'artifactを利用'), 'schema、size');
+  expectRejected(manuscript, 'missing official source', (value) => value.replace('https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target', 'https://example.invalid'), 'securely-using');
+  console.log('GitHub Actions trust-boundary contract self-test passed.');
+} else {
+  console.log('GitHub Actions trust-boundary contract passed: fork PR, privileged context, and two-stage boundaries.');
+}

--- a/scripts/check-github-actions-trust-boundary.js
+++ b/scripts/check-github-actions-trust-boundary.js
@@ -48,11 +48,11 @@ function validate(content) {
     if (!content.includes(marker)) errors.push(`必須markerがありません: ${marker}`);
   }
 
-  const yamlBlocks = [...content.matchAll(/```yaml\n([\s\S]*?)\n```/g)].map((match) => match[1]);
+  const yamlBlocks = [...content.matchAll(/```(?:yaml|yml)\n([\s\S]*?)\n```/gi)].map((match) => match[1]);
   if (!yamlBlocks.some((block) => block.includes('pull_request:') && block.includes('contents: read'))) {
     errors.push('pull_request + contents: readの安全な基本例がありません');
   }
-  if (yamlBlocks.some((block) => block.includes('pull_request_target:'))) {
+  if (yamlBlocks.some((block) => /\bpull_request_target\b/.test(block.replace(/^\s*#.*$/gm, '')))) {
     errors.push('copy可能なYAML例にpull_request_targetを含めてはいけません');
   }
   if (yamlBlocks.some((block) => /permissions:\s*(?:write-all|read-all)/.test(block) || /contents:\s*write/.test(block))) {
@@ -109,6 +109,8 @@ if (process.argv.includes('--self-test')) {
   expectRejected(manuscript, 'missing pull_request', (value) => value.replace('on:\n  pull_request:', 'on:\n  push:'), 'pull_request:');
   expectRejected(manuscript, 'broad write', (value) => value.replace('contents: read', 'contents: write'), 'write権限');
   expectRejected(manuscript, 'unsafe target YAML', (value) => value.replace('pull_request:', 'pull_request_target:'), 'pull_request_target');
+  expectRejected(manuscript, 'unsafe target yml inline list', (value) => `${value}\n\n\`\`\`yml\non: [pull_request_target]\n\`\`\``, 'pull_request_target');
+  expectRejected(manuscript, 'unsafe target YAML scalar', (value) => `${value}\n\n\`\`\`yaml\non: pull_request_target\n\`\`\``, 'pull_request_target');
   expectRejected(manuscript, 'missing fork approval boundary', (value) => value.replace('`pull_request_target`はfork workflowの承認設定に依存せず', '`pull_request_target`は承認後に実行され'), '承認設定に依存せず');
   expectRejected(manuscript, 'missing head-code ban', (value) => value.replace('任意commandを実行してはいけません', '任意commandを実行できます'), '任意command');
   expectRejected(manuscript, 'missing two-stage validation', (value) => value.replace('schema、size、対象PR、producer run、digestを検証', 'artifactを利用'), 'schema、size');


### PR DESCRIPTION
## 概要

GitHub Actions章に、`pull_request`と`pull_request_target`のtrust boundary、およびprivileged writeを安全に分離する2-stage設計を追加します。

## 変更内容

- fork PRの基本を`pull_request` + `contents: read`として明示
- public forkのread-only token/no secretsと、private repository設定の例外を区別
- `pull_request_target`がbase repository/default branch context、base token/secretsで動くことを明示
- public fork approval設定に依存せず実行されるため、contributor承認を安全装置として期待しない旨を追記
- untrusted head SHAのcheckout、build/test/install script/任意command実行を禁止
- metadata-only処理と、`workflow_run`/手動承認を使う2-stage privileged writeを説明
- artifactのschema/size/PR/producer run/digest検証、`runner.temp`、script/binary非実行を明示
- manuscript/docs exact mirror、必須境界、CI/package wiringを検査する回帰checkerとself-testを追加

## 検証

- Node.js 24.18.0 / npm 11.16.0: `npm ci`
- `npm test`
- `npm run docs:quality-gate`
- Jekyll build
- `npm audit`（0 vulnerabilities）
- 変更2ファイルのmarkdownlint、internal links、外部GitHub Docs 4/4
- bidi Unicode check
- `git diff --check`
- 独立security review: 最終 actionable High 0 / Medium 0 / Low 0

Jekyllでは既存のRuby標準library/Sass deprecation warningが出ますが、buildは成功しています。

## 残存制約

実fork PRでのtoken/secrets観測はテスト用repositoryを作成していないため未実施です。GitHub一次情報、静的契約、負例self-test、GitHub Actions CIで代替します。

Closes #235
