### PR TITLE
docs: branch protectionとrulesetsの使い分けを明示する

### DIFF
--- a/docs/chapters/chapter-branch-operations/index.md
+++ b/docs/chapters/chapter-branch-operations/index.md
@@ -257,7 +257,23 @@ Pull Request は「作ったら終わり」ではありません。初心者向�
 | CI | 必須チェックが成功している | Checks タブで失敗 job がないことを確認する |
 | merge 後 | main のチェックと公開先に反映された | merge 後の Actions / Pages / 動作確認を Issue に記録する |
 
-ブランチ保護や ruleset を使うと、レビュー、status checks、conversation resolution などをマージ条件として機械的に要求できます。個人学習では任意ですが、チーム開発では早めに導入すると事故を減らせます。
+ブランチ保護や ruleset を使うと、レビュー、status checks、conversation resolution などをマージ条件として機械的に要求できます。本書では、個人学習では任意、チーム開発では最低限の merge gate として早めに導入することを推奨します。
+
+### branch protection rule と rulesets の整理（2026-07-19時点）
+
+GitHub 公式仕様では、branch protection rule と rulesets は別機能です。rulesets を branch protection の単なる名称変更として扱わないでください。
+
+- **branch protection rule** は、特定の branch 名または `fnmatch` pattern を対象に設定します。ただし、同じ branch に同時適用される branch protection rule は常に 1 件だけです。優先順位は、specific branch rule が最優先、同じ specific branch を指す rule 同士では古い rule が優先、`*` などの特殊文字を含む wildcard rule 同士では作成順で古い rule が優先、です。
+- **rulesets** は branch または tag を対象にでき、複数の ruleset を同じ branch や tag に重ねて適用できます。さらに rulesets は branch protection rule とも重なって評価され、同じ種類の rule が複数定義されている場合は、より厳しい設定が有効になります。
+- **active ruleset の確認** は admin 権限なしでも可能です。read 権限があれば、リポジトリの `/rules` や branch 一覧から対象 ruleset を確認できます。Pull Request の merge box に rule が表示された場合は、merge を妨げている条件も確認できます。
+- **enforcement status** は、Free / Pro / Team 向けの一般 docs では `Active` と `Disabled` が案内されています。Enterprise Cloud 向け docs では `Evaluate` も案内されており、利用できる環境では Rule Insights で非強制の評価結果を見てから `Active` へ進めます。
+
+**GitHub Docs（2026-07-19確認）**
+- [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule)
+- [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+- [Creating rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
+- [Managing rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository)
 
 ### 作業用ブランチの削除
 

--- a/docs/chapters/chapter-security-best-practices/index.md
+++ b/docs/chapters/chapter-security-best-practices/index.md
@@ -213,10 +213,27 @@ git gc --prune=now --aggressive
 
 ### 開発フロー
 
-1. **ブランチ保護 / ruleset**: mainブランチへの直接プッシュを禁止し、必要に応じて ruleset で対象ブランチや tag の条件を管理する
+1. **branch protection rule / rulesets**: mainブランチへの直接プッシュを禁止し、branch protection rule と rulesets を使い分ける。branch protection rule は 1 つの branch に 1 件しか同時適用されない一方、rulesets は branch/tag を対象に複数重ねられるため、同じものとして扱わない
 2. **プルリクエストレビュー**: 必須レビュー、最新 push の再レビュー、conversation resolution を設定する
 3. **ステータスチェック**: CI/CDでのテスト、lint、セキュリティチェックを必須化する
 4. **merge 後確認**: main の Actions、Pages、リリース先を確認し、Issue に証跡を残す
+
+### branch protection / ruleset 運用の最小原則
+
+- bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request と audit log に変更の軌跡を残せます。
+- この `For pull requests only` は ruleset の bypass 設定です。branch protection rule 側では bypass list に actor を追加できるのは organization 所有 repository の場合だけなので、両者を混同しないでください。
+- branch protection rule は特定 branch 名または `fnmatch` pattern を対象にできますが、同じ branch に同時適用される rule は 1 件だけです。specific branch rule が優先され、同じ specific branch への rule が複数ある場合は古い rule が優先されます。`*` などを含む wildcard rule 同士も古い rule が優先されます。
+- rulesets は branch または tag を対象にでき、複数 ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。
+- active ruleset は read 権限で確認できます。`/rules` や branch 一覧で対象 ruleset を確認し、Pull Request の merge box に rule が表示された場合は、merge を妨げている条件を確認します。
+- Free / Pro / Team 向けの一般 docs では ruleset の status として `Active` と `Disabled` が案内されています。Enterprise Cloud 向け docs では `Evaluate` も案内されており、利用できる環境では Rule Insights で非強制の評価結果を確認してから `Active` に進めます。
+- **本書の推奨**: 個人学習用 repository では branch protection や rulesets は任意とし、team operation では必須レビューと必須 status checks を含む minimum merge gate として利用します。
+
+**GitHub Docs（2026-07-19確認）**
+- [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule)
+- [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+- [Creating rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
+- [Managing rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository)
 
 ### チームでのセキュリティ文化
 

--- a/docs/chapters/chapter-security-best-practices/index.md
+++ b/docs/chapters/chapter-security-best-practices/index.md
@@ -213,20 +213,20 @@ git gc --prune=now --aggressive
 
 ### 開発フロー
 
-1. **branch protection rule / rulesets**: mainブランチへの直接プッシュを禁止し、branch protection rule と rulesets を使い分ける。branch protection rule は 1 つの branch に 1 件しか同時適用されない一方、rulesets は branch/tag を対象に複数重ねられるため、同じものとして扱わない
+1. **branch protection rule / rulesets**: mainブランチへの直接プッシュを禁止し、branch protection rule と rulesets を使い分ける。branch protection rule は 1 つの branch に 1 件しか同時適用されない一方、rulesets は branch/tag を対象に複数重ねられるため、適用 model に応じて使い分ける
 2. **プルリクエストレビュー**: 必須レビュー、最新 push の再レビュー、conversation resolution を設定する
 3. **ステータスチェック**: CI/CDでのテスト、lint、セキュリティチェックを必須化する
 4. **merge 後確認**: main の Actions、Pages、リリース先を確認し、Issue に証跡を残す
 
-### branch protection / ruleset 運用の最小原則
+### branch protection rule / rulesets 運用の最小原則
 
 - bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request と audit log に変更の軌跡を残せます。
 - この `For pull requests only` は ruleset の bypass 設定です。branch protection rule 側では bypass list に actor を追加できるのは organization 所有 repository の場合だけなので、両者を混同しないでください。
 - branch protection rule は特定 branch 名または `fnmatch` pattern を対象にできますが、同じ branch に同時適用される rule は 1 件だけです。specific branch rule が優先され、同じ specific branch への rule が複数ある場合は古い rule が優先されます。`*` などを含む wildcard rule 同士も古い rule が優先されます。
-- rulesets は branch または tag を対象にでき、複数 ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。
+- rulesets は branch または tag を対象にでき、複数の ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。
 - active ruleset は read 権限で確認できます。`/rules` や branch 一覧で対象 ruleset を確認し、Pull Request の merge box に rule が表示された場合は、merge を妨げている条件を確認します。
 - Free / Pro / Team 向けの一般 docs では ruleset の status として `Active` と `Disabled` が案内されています。Enterprise Cloud 向け docs では `Evaluate` も案内されており、利用できる環境では Rule Insights で非強制の評価結果を確認してから `Active` に進めます。
-- **本書の推奨**: 個人学習用 repository では branch protection や rulesets は任意とし、team operation では必須レビューと必須 status checks を含む minimum merge gate として利用します。
+- **本書の推奨**: 個人学習用 repository では branch protection や rulesets は任意とし、team operation では必須レビューと必須 status checks を含む最低限の merge gate として利用します。
 
 **GitHub Docs（2026-07-19確認）**
 - [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)

--- a/docs/chapters/chapter-security-best-practices/index.md
+++ b/docs/chapters/chapter-security-best-practices/index.md
@@ -220,7 +220,7 @@ git gc --prune=now --aggressive
 
 ### branch protection rule / rulesets 運用の最小原則
 
-- bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request と audit log に変更の軌跡を残せます。
+- bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request に変更の軌跡を残せます。organization 所有 repository では、その操作を organization の audit log でも確認できます。
 - この `For pull requests only` は ruleset の bypass 設定です。branch protection rule 側では bypass list に actor を追加できるのは organization 所有 repository の場合だけなので、両者を混同しないでください。
 - branch protection rule は特定 branch 名または `fnmatch` pattern を対象にできますが、同じ branch に同時適用される rule は 1 件だけです。specific branch rule が優先され、同じ specific branch への rule が複数ある場合は古い rule が優先されます。`*` などを含む wildcard rule 同士も古い rule が優先されます。
 - rulesets は branch または tag を対象にでき、複数の ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。

--- a/manuscript/chapter-branch-operations/index.md
+++ b/manuscript/chapter-branch-operations/index.md
@@ -257,7 +257,23 @@ Pull Request は「作ったら終わり」ではありません。初心者向�
 | CI | 必須チェックが成功している | Checks タブで失敗 job がないことを確認する |
 | merge 後 | main のチェックと公開先に反映された | merge 後の Actions / Pages / 動作確認を Issue に記録する |
 
-ブランチ保護や ruleset を使うと、レビュー、status checks、conversation resolution などをマージ条件として機械的に要求できます。個人学習では任意ですが、チーム開発では早めに導入すると事故を減らせます。
+ブランチ保護や ruleset を使うと、レビュー、status checks、conversation resolution などをマージ条件として機械的に要求できます。本書では、個人学習では任意、チーム開発では最低限の merge gate として早めに導入することを推奨します。
+
+### branch protection rule と rulesets の整理（2026-07-19時点）
+
+GitHub 公式仕様では、branch protection rule と rulesets は別機能です。rulesets を branch protection の単なる名称変更として扱わないでください。
+
+- **branch protection rule** は、特定の branch 名または `fnmatch` pattern を対象に設定します。ただし、同じ branch に同時適用される branch protection rule は常に 1 件だけです。優先順位は、specific branch rule が最優先、同じ specific branch を指す rule 同士では古い rule が優先、`*` などの特殊文字を含む wildcard rule 同士では作成順で古い rule が優先、です。
+- **rulesets** は branch または tag を対象にでき、複数の ruleset を同じ branch や tag に重ねて適用できます。さらに rulesets は branch protection rule とも重なって評価され、同じ種類の rule が複数定義されている場合は、より厳しい設定が有効になります。
+- **active ruleset の確認** は admin 権限なしでも可能です。read 権限があれば、リポジトリの `/rules` や branch 一覧から対象 ruleset を確認できます。Pull Request の merge box に rule が表示された場合は、merge を妨げている条件も確認できます。
+- **enforcement status** は、Free / Pro / Team 向けの一般 docs では `Active` と `Disabled` が案内されています。Enterprise Cloud 向け docs では `Evaluate` も案内されており、利用できる環境では Rule Insights で非強制の評価結果を見てから `Active` へ進めます。
+
+**GitHub Docs（2026-07-19確認）**
+- [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule)
+- [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+- [Creating rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
+- [Managing rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository)
 
 ### 作業用ブランチの削除
 

--- a/manuscript/chapter-security-best-practices/index.md
+++ b/manuscript/chapter-security-best-practices/index.md
@@ -213,10 +213,27 @@ git gc --prune=now --aggressive
 
 ### 開発フロー
 
-1. **ブランチ保護 / ruleset**: mainブランチへの直接プッシュを禁止し、必要に応じて ruleset で対象ブランチや tag の条件を管理する
+1. **branch protection rule / rulesets**: mainブランチへの直接プッシュを禁止し、branch protection rule と rulesets を使い分ける。branch protection rule は 1 つの branch に 1 件しか同時適用されない一方、rulesets は branch/tag を対象に複数重ねられるため、同じものとして扱わない
 2. **プルリクエストレビュー**: 必須レビュー、最新 push の再レビュー、conversation resolution を設定する
 3. **ステータスチェック**: CI/CDでのテスト、lint、セキュリティチェックを必須化する
 4. **merge 後確認**: main の Actions、Pages、リリース先を確認し、Issue に証跡を残す
+
+### branch protection / ruleset 運用の最小原則
+
+- bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request と audit log に変更の軌跡を残せます。
+- この `For pull requests only` は ruleset の bypass 設定です。branch protection rule 側では bypass list に actor を追加できるのは organization 所有 repository の場合だけなので、両者を混同しないでください。
+- branch protection rule は特定 branch 名または `fnmatch` pattern を対象にできますが、同じ branch に同時適用される rule は 1 件だけです。specific branch rule が優先され、同じ specific branch への rule が複数ある場合は古い rule が優先されます。`*` などを含む wildcard rule 同士も古い rule が優先されます。
+- rulesets は branch または tag を対象にでき、複数 ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。
+- active ruleset は read 権限で確認できます。`/rules` や branch 一覧で対象 ruleset を確認し、Pull Request の merge box に rule が表示された場合は、merge を妨げている条件を確認します。
+- Free / Pro / Team 向けの一般 docs では ruleset の status として `Active` と `Disabled` が案内されています。Enterprise Cloud 向け docs では `Evaluate` も案内されており、利用できる環境では Rule Insights で非強制の評価結果を確認してから `Active` に進めます。
+- **本書の推奨**: 個人学習用 repository では branch protection や rulesets は任意とし、team operation では必須レビューと必須 status checks を含む minimum merge gate として利用します。
+
+**GitHub Docs（2026-07-19確認）**
+- [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [Managing a branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule)
+- [About rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+- [Creating rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
+- [Managing rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository)
 
 ### チームでのセキュリティ文化
 

--- a/manuscript/chapter-security-best-practices/index.md
+++ b/manuscript/chapter-security-best-practices/index.md
@@ -213,20 +213,20 @@ git gc --prune=now --aggressive
 
 ### 開発フロー
 
-1. **branch protection rule / rulesets**: mainブランチへの直接プッシュを禁止し、branch protection rule と rulesets を使い分ける。branch protection rule は 1 つの branch に 1 件しか同時適用されない一方、rulesets は branch/tag を対象に複数重ねられるため、同じものとして扱わない
+1. **branch protection rule / rulesets**: mainブランチへの直接プッシュを禁止し、branch protection rule と rulesets を使い分ける。branch protection rule は 1 つの branch に 1 件しか同時適用されない一方、rulesets は branch/tag を対象に複数重ねられるため、適用 model に応じて使い分ける
 2. **プルリクエストレビュー**: 必須レビュー、最新 push の再レビュー、conversation resolution を設定する
 3. **ステータスチェック**: CI/CDでのテスト、lint、セキュリティチェックを必須化する
 4. **merge 後確認**: main の Actions、Pages、リリース先を確認し、Issue に証跡を残す
 
-### branch protection / ruleset 運用の最小原則
+### branch protection rule / rulesets 運用の最小原則
 
 - bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request と audit log に変更の軌跡を残せます。
 - この `For pull requests only` は ruleset の bypass 設定です。branch protection rule 側では bypass list に actor を追加できるのは organization 所有 repository の場合だけなので、両者を混同しないでください。
 - branch protection rule は特定 branch 名または `fnmatch` pattern を対象にできますが、同じ branch に同時適用される rule は 1 件だけです。specific branch rule が優先され、同じ specific branch への rule が複数ある場合は古い rule が優先されます。`*` などを含む wildcard rule 同士も古い rule が優先されます。
-- rulesets は branch または tag を対象にでき、複数 ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。
+- rulesets は branch または tag を対象にでき、複数の ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。
 - active ruleset は read 権限で確認できます。`/rules` や branch 一覧で対象 ruleset を確認し、Pull Request の merge box に rule が表示された場合は、merge を妨げている条件を確認します。
 - Free / Pro / Team 向けの一般 docs では ruleset の status として `Active` と `Disabled` が案内されています。Enterprise Cloud 向け docs では `Evaluate` も案内されており、利用できる環境では Rule Insights で非強制の評価結果を確認してから `Active` に進めます。
-- **本書の推奨**: 個人学習用 repository では branch protection や rulesets は任意とし、team operation では必須レビューと必須 status checks を含む minimum merge gate として利用します。
+- **本書の推奨**: 個人学習用 repository では branch protection や rulesets は任意とし、team operation では必須レビューと必須 status checks を含む最低限の merge gate として利用します。
 
 **GitHub Docs（2026-07-19確認）**
 - [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)

--- a/manuscript/chapter-security-best-practices/index.md
+++ b/manuscript/chapter-security-best-practices/index.md
@@ -220,7 +220,7 @@ git gc --prune=now --aggressive
 
 ### branch protection rule / rulesets 運用の最小原則
 
-- bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request と audit log に変更の軌跡を残せます。
+- bypass 権限は最小化します。ruleset では `For pull requests only` を選ぶと、直接 push を許可せず、Pull Request に変更の軌跡を残せます。organization 所有 repository では、その操作を organization の audit log でも確認できます。
 - この `For pull requests only` は ruleset の bypass 設定です。branch protection rule 側では bypass list に actor を追加できるのは organization 所有 repository の場合だけなので、両者を混同しないでください。
 - branch protection rule は特定 branch 名または `fnmatch` pattern を対象にできますが、同じ branch に同時適用される rule は 1 件だけです。specific branch rule が優先され、同じ specific branch への rule が複数ある場合は古い rule が優先されます。`*` などを含む wildcard rule 同士も古い rule が優先されます。
 - rulesets は branch または tag を対象にでき、複数の ruleset と branch protection rule が layer されます。同じ rule が複数ある場合は most restrictive が適用されます。


### PR DESCRIPTION
## 概要（必須）

- 変更内容: branch protection ruleとrulesetsを別機能として整理し、適用model、priority/layering、view/evaluation、bypass、personal/team運用の選択基準を明示しました。

## 関連Issue/仕様（必須）

- Issue: Closes #234
- 仕様（要点）: branch protectionは同一branchへ1 rule、rulesetsはbranch/tagへ複数layer、同じruleはmost restrictive、active rulesetの確認方法とbypass設計をGitHub公式仕様に合わせます。

## 影響範囲（必須）

- 対象章/ページ:
  - `/chapters/chapter-branch-operations/`
  - `/chapters/chapter-security-best-practices/`
- 影響: minimum merge gateとsecurity運用説明の追記。slug、navigation、repository settingsは変更しません。

## 受入基準（必須）

- [x] Issue の受入基準を満たす
- [x] 変更禁止領域に触れていない
- [x] 章参照・内部リンク・アンカーが壊れていない
- [x] manuscript正本とdocs公開コピーがbyte-for-byte一致する

## テスト/検証（必須）

- `mise exec node@24 -- npm ci --no-fund --no-audit`: PASS
- 変更4 Markdownのmarkdownlint / internal link: PASS
- 追加したGitHub公式リンク10箇所: HTTP check PASS
  - 既存Liquid template `https://github.com/{{ ... }}`だけはmarkdown-link-checkが404として検出する既知false positive
- `python3 scripts/check_bidi_unicode.py`: PASS
- `mise exec node@24 -- npm test`: PASS
- `mise exec node@24 -- npm run docs:quality-gate`: PASS
- `mise exec node@24 -- npm audit`: PASS、0 vulnerabilities
- `mise exec node@24 -- npm run build`: PASS（既存Jekyll/Sass deprecation warningのみ）
- `cmp` 2 pair / `git diff --check`: PASS
- 独立fact review: 初回2件（Evaluateの可用性表現、personal/teamの推奨明示）を修正後、actionable finding 0
- GitHub公式Docsを2026-07-19に再確認

## リスク/ロールバック（必須）

- リスク: GitHubのplan構成・Docsは将来変更され得ます。確認日を本文に明記し、Evaluateの利用可否は断定せずDocs版の記載差として説明しています。
- test repositoryでrulesetを重ねるE2Eは、実repository settings非変更の対象外制約と安全に利用できる専用repositoryがないため未実施です。公式仕様、mirror検査、独立fact review、CIで代替します。
- ロールバック手順: 本PRのsquash merge commitをrevertします。

## Review 対応（必須）

- [x] review 本文・inline comment・suggestion を全件確認した
- [x] 修正した指摘には返信した
- [x] 修正しない指摘には理由を返信した
- [x] 未解決の review thread が 0 件である

## QA（必須）

- [x] Book QA: PASS
  - 実行URL: https://github.com/itdojp/github-guide-for-beginners-book/actions/runs/29686691352
- [x] Docs Quality Gate: PASS
  - 実行URL: https://github.com/itdojp/github-guide-for-beginners-book/actions/runs/29686691353
- [x] Docs Forbidden Check: PASS
  - 実行URL: https://github.com/itdojp/github-guide-for-beginners-book/actions/runs/29686691355
- [x] 必須 status checks が green である

## merge 後確認（原則必須）

- [x] main の checks が green である
- [x] Pagesと公開先のsmoke testを実施した
- [x] 完了証跡をIssue #234に記録した

## Pages確認（原則必須）

- [x] top HTTP 200
- [x] `/chapters/chapter-branch-operations/` HTTP 200 + marker確認
- [x] `/chapters/chapter-security-best-practices/` HTTP 200 + marker確認

## AI支援/エージェント利用の開示（任意）

- AI/エージェント利用: 有
- 利用範囲: 本文下書き、公式仕様調査、独立fact review、検証


